### PR TITLE
deps(irisadapter): upgrade iris to v0.11.0

### DIFF
--- a/irisadapter/go.mod
+++ b/irisadapter/go.mod
@@ -3,13 +3,11 @@ module github.com/petal-labs/petalflow/irisadapter
 go 1.24.0
 
 require (
-	github.com/petal-labs/iris v0.10.0
+	github.com/petal-labs/iris v0.11.0
 	github.com/petal-labs/petalflow v0.1.0
 )
 
 require github.com/google/uuid v1.6.0 // indirect
 
-// Development replace directives - remove once packages are published
+// Development replace directive - remove once petalflow is published
 replace github.com/petal-labs/petalflow => ../
-
-replace github.com/petal-labs/iris => /Users/erikhoward/src/github/petal-labs/iris

--- a/irisadapter/go.sum
+++ b/irisadapter/go.sum
@@ -1,2 +1,4 @@
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/petal-labs/iris v0.11.0 h1:YWm2etDvR7UUqvF7dmGnP0+UN0vBxbotczWvHhahjNM=
+github.com/petal-labs/iris v0.11.0/go.mod h1:kK5XEFDRd/zz9m23Hh1G5knFdx8ScXNEKj2ri6QVY6I=


### PR DESCRIPTION
## Summary

- Upgrade iris dependency from v0.10.0 to v0.11.0
- Remove local replace directive for iris (now using published module)

## Changes in Iris v0.11.0

- Tool Result Injection for multi-turn tool use
- Agent Loop with Parallel Tool Execution
- Middleware System for Tool Execution
- Memory Management with Auto-Summarization

## Test plan

- [x] All irisadapter tests pass (19/19)
- [x] Verified compatibility with published iris v0.11.0 module

🤖 Generated with [Claude Code](https://claude.ai/code)