### PR TITLE
feat(irisadapter): expose Iris v0.11.0 tool features

### DIFF
--- a/petalflow.go
+++ b/petalflow.go
@@ -77,6 +77,12 @@ type (
 	// LLMToolCall represents a tool invocation requested by the model.
 	LLMToolCall = core.LLMToolCall
 
+	// LLMToolResult represents the result of executing a tool.
+	LLMToolResult = core.LLMToolResult
+
+	// LLMReasoningOutput contains reasoning information from the model.
+	LLMReasoningOutput = core.LLMReasoningOutput
+
 	// PetalTool is the tool interface for PetalFlow.
 	PetalTool = core.PetalTool
 


### PR DESCRIPTION
## Summary

- Add support for Iris v0.11.0's tool result injection for multi-turn tool use
- Expose reasoning output from models that support it
- Add Instructions field for Responses API style prompts
- Add Status field for response completion tracking

## New Types

| Type | Purpose |
|------|---------|
| `LLMToolResult` | Represents tool execution results with `CallID`, `Content`, `IsError` |
| `LLMReasoningOutput` | Captures reasoning with `ID` and `Summary []string` |

## Extended Types

| Type | New Fields |
|------|------------|
| `LLMMessage` | `ToolCalls`, `ToolResults` |
| `LLMRequest` | `Instructions` |
| `LLMResponse` | `Reasoning`, `Status` |

## Test plan

- [x] All 25 irisadapter tests pass (6 new tests added)
- [x] All PetalFlow tests pass (backward compatibility verified)