### PR TITLE
chore: add Makefile and multi-platform release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,11 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -25,11 +23,79 @@ jobs:
       - name: Run tests
         run: go test -v ./...
 
-      - name: Extract release notes
-        id: release_notes
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+            suffix: ''
+          - goos: darwin
+            goarch: arm64
+            suffix: ''
+          - goos: windows
+            goarch: amd64
+            suffix: '.exe'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+
+      - name: Build binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '0'
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          OUTPUT="petalflow-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}"
+          go build -ldflags="-s -w -X main.version=${VERSION}" -o "${OUTPUT}" ./cmd/petalflow
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: petalflow-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: petalflow-${{ matrix.goos }}-${{ matrix.goarch }}${{ matrix.suffix }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release assets
+        id: prepare
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+          mkdir -p release
+          # Move binaries from artifact subdirectories into release/
+          for dir in artifacts/*/; do
+            cp "${dir}"* release/
+          done
+
+          # Generate checksums
+          cd release
+          sha256sum petalflow-* > checksums-sha256.txt
+
+      - name: Extract release notes
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
 
           # Extract release notes from CHANGELOG.md for this version
           awk '/^## \['"$VERSION"'\]/{flag=1; next} /^## \[/{flag=0} flag' CHANGELOG.md > release_notes.md
@@ -46,6 +112,9 @@ jobs:
           draft: false
           prerelease: ${{ contains(github.ref, '-rc') || contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}
           generate_release_notes: false
+          files: |
+            release/petalflow-*
+            release/checksums-sha256.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,42 @@
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+LDFLAGS  = -s -w -X main.version=$(VERSION)
+BINARY   = petalflow
+CMD      = ./cmd/petalflow
+
+.PHONY: build test lint vet coverage clean cross snapshot-update
+
+## build: compile the CLI binary
+build:
+	go build -ldflags='$(LDFLAGS)' -o $(BINARY) $(CMD)
+
+## test: run all tests with race detector
+test:
+	go test -race ./...
+
+## lint: run golangci-lint
+lint:
+	golangci-lint run
+
+## vet: run go vet
+vet:
+	go vet ./...
+
+## coverage: run tests and open coverage report
+coverage:
+	go test -race -coverprofile=coverage.out -covermode=atomic ./...
+	go tool cover -html=coverage.out -o coverage.html
+
+## cross: build release binaries for all platforms
+cross:
+	CGO_ENABLED=0 GOOS=linux   GOARCH=amd64 go build -ldflags='$(LDFLAGS)' -o $(BINARY)-linux-amd64     $(CMD)
+	CGO_ENABLED=0 GOOS=darwin  GOARCH=arm64 go build -ldflags='$(LDFLAGS)' -o $(BINARY)-darwin-arm64     $(CMD)
+	CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags='$(LDFLAGS)' -o $(BINARY)-windows-amd64.exe $(CMD)
+
+## snapshot-update: regenerate golden test files
+snapshot-update:
+	go test ./agent/ -run TestCompileSnapshots -update
+
+## clean: remove build artifacts
+clean:
+	rm -f $(BINARY) $(BINARY)-linux-amd64 $(BINARY)-darwin-arm64 $(BINARY)-windows-amd64.exe
+	rm -f coverage.out coverage.html


### PR DESCRIPTION
## Summary

- **Makefile**: Adds common development targets — `build`, `test` (with race detector), `lint`, `vet`, `coverage`, `cross` (multi-platform binaries), `snapshot-update`, and `clean`
- **Release workflow**: Restructures `.github/workflows/release.yml` from a single job into a three-stage pipeline:
  1. **test** — runs `go test -v ./...`
  2. **build** — matrix build for linux/amd64, darwin/arm64, windows/amd64 with `CGO_ENABLED=0` and version injection via `-ldflags`
  3. **release** — downloads artifacts, generates SHA-256 checksums, attaches binaries to the GitHub release

## Test plan

- [x] Makefile targets verified locally (`make build`, `make test`, `make cross`, `make clean`)
- [x] YAML syntax validated
- [ ] Full workflow runs on next tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)