### PR TITLE
fix: deterministic edge ordering in agent compiler

### DIFF
--- a/agent/compile.go
+++ b/agent/compile.go
@@ -189,6 +189,20 @@ func Compile(wf *AgentWorkflow) (*graph.GraphDefinition, error) {
 		return nil, fmt.Errorf("unsupported execution strategy %q", wf.Execution.Strategy)
 	}
 
+	sort.Slice(gd.Edges, func(i, j int) bool {
+		ei, ej := gd.Edges[i], gd.Edges[j]
+		if ei.Source != ej.Source {
+			return ei.Source < ej.Source
+		}
+		if ei.Target != ej.Target {
+			return ei.Target < ej.Target
+		}
+		if ei.SourceHandle != ej.SourceHandle {
+			return ei.SourceHandle < ej.SourceHandle
+		}
+		return ei.TargetHandle < ej.TargetHandle
+	})
+
 	return gd, nil
 }
 

--- a/agent/testdata/sequential_simple.golden.json
+++ b/agent/testdata/sequential_simple.golden.json
@@ -34,13 +34,13 @@
       "source": "research__researcher",
       "sourceHandle": "output",
       "target": "write__writer",
-      "targetHandle": "research_data"
+      "targetHandle": "input"
     },
     {
       "source": "research__researcher",
       "sourceHandle": "output",
       "target": "write__writer",
-      "targetHandle": "input"
+      "targetHandle": "research_data"
     }
   ],
   "entry": "research__researcher"


### PR DESCRIPTION
## Summary

- Sort `gd.Edges` by `(Source, Target, SourceHandle, TargetHandle)` before returning from `Compile()` to eliminate non-deterministic output caused by Go map iteration order
- Regenerate golden snapshot files to match the now-stable sorted order

Closes #21

## Test plan

- [x] `TestCompileSnapshots/custom_dag` passes consistently (verified 20 consecutive runs)
- [x] Full test suite (`go test ./...`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)