### PR TITLE
feat: add OpenAI integration tests with daily CI workflow

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,28 @@
+name: Integration Tests
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
+
+jobs:
+  integration:
+    runs-on: ubuntu-latest
+    environment: CI
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.24.x"
+          cache: true
+      - name: Verify required secrets
+        env:
+          HAS_OPENAI: ${{ secrets.OPENAI_API_KEY != '' }}
+        run: |
+          if [ "$HAS_OPENAI" != "true" ]; then
+            echo "ERROR: Missing required secret OPENAI_API_KEY"
+            exit 1
+          fi
+      - name: Run integration tests
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: go test -tags=integration ./tests/integration/... -count=1 -v -timeout 120s

--- a/tests/integration/embedding_test.go
+++ b/tests/integration/embedding_test.go
@@ -1,0 +1,87 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	iriscore "github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/openai"
+)
+
+func TestEmbedding_SingleInput(t *testing.T) {
+	skipIfNoAPIKey(t)
+
+	provider := openai.New(getAPIKey(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := provider.CreateEmbeddings(ctx, &iriscore.EmbeddingRequest{
+		Model: "text-embedding-3-small",
+		Input: []iriscore.EmbeddingInput{
+			{Text: "Hello, world!"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddings: %v", err)
+	}
+
+	if len(resp.Vectors) != 1 {
+		t.Fatalf("expected 1 vector, got %d", len(resp.Vectors))
+	}
+
+	vec := resp.Vectors[0]
+	if len(vec.Vector) != 1536 {
+		t.Fatalf("expected 1536 dimensions, got %d", len(vec.Vector))
+	}
+
+	if resp.Usage.TotalTokens == 0 {
+		t.Fatal("expected non-zero total tokens")
+	}
+
+	t.Logf("Embedding: %d dimensions, usage: prompt=%d total=%d",
+		len(vec.Vector), resp.Usage.PromptTokens, resp.Usage.TotalTokens)
+}
+
+func TestEmbedding_BatchInput(t *testing.T) {
+	skipIfNoAPIKey(t)
+
+	provider := openai.New(getAPIKey(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	inputs := []iriscore.EmbeddingInput{
+		{Text: "The quick brown fox jumps over the lazy dog"},
+		{Text: "Machine learning is a subset of artificial intelligence"},
+		{Text: "Go is a statically typed programming language"},
+	}
+
+	resp, err := provider.CreateEmbeddings(ctx, &iriscore.EmbeddingRequest{
+		Model: "text-embedding-3-small",
+		Input: inputs,
+	})
+	if err != nil {
+		t.Fatalf("CreateEmbeddings: %v", err)
+	}
+
+	if len(resp.Vectors) != 3 {
+		t.Fatalf("expected 3 vectors, got %d", len(resp.Vectors))
+	}
+
+	for i, vec := range resp.Vectors {
+		if len(vec.Vector) != 1536 {
+			t.Errorf("vector[%d]: expected 1536 dimensions, got %d", i, len(vec.Vector))
+		}
+	}
+
+	if resp.Usage.TotalTokens == 0 {
+		t.Fatal("expected non-zero total tokens")
+	}
+
+	t.Logf("Batch embedding: %d vectors, usage: prompt=%d total=%d",
+		len(resp.Vectors), resp.Usage.PromptTokens, resp.Usage.TotalTokens)
+}

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -1,0 +1,85 @@
+//go:build integration
+
+// Package integration contains integration tests that call real external APIs.
+// These tests are excluded from normal `go test ./...` runs and require:
+//
+//	go test -tags=integration ./tests/integration/... -v -count=1
+package integration
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/petal-labs/petalflow/core"
+	"github.com/petal-labs/petalflow/hydrate"
+	"github.com/petal-labs/petalflow/llmprovider"
+)
+
+// isCI returns true when running inside a CI environment.
+func isCI() bool {
+	for _, key := range []string{"CI", "GITHUB_ACTIONS", "CIRCLECI", "TRAVIS"} {
+		if os.Getenv(key) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// skipOrFailOnMissingKey fatals in CI (secrets should always be present)
+// and skips locally (developer may not have the key).
+func skipOrFailOnMissingKey(t *testing.T, keyName string) {
+	t.Helper()
+	if isCI() {
+		t.Fatalf("required secret %s is not set in CI", keyName)
+	}
+	t.Skipf("%s not set, skipping integration test", keyName)
+}
+
+// skipIfNoAPIKey skips or fatals if OPENAI_API_KEY is not available.
+func skipIfNoAPIKey(t *testing.T) {
+	t.Helper()
+	if os.Getenv("OPENAI_API_KEY") == "" {
+		skipOrFailOnMissingKey(t, "OPENAI_API_KEY")
+	}
+}
+
+// getAPIKey returns the OPENAI_API_KEY or fatals.
+func getAPIKey(t *testing.T) string {
+	t.Helper()
+	key := os.Getenv("OPENAI_API_KEY")
+	if key == "" {
+		t.Fatal("OPENAI_API_KEY is not set")
+	}
+	return key
+}
+
+// newOpenAIClient returns a core.LLMClient backed by the OpenAI provider.
+// The returned client implements both LLMClient and StreamingLLMClient.
+func newOpenAIClient(t *testing.T) core.LLMClient {
+	t.Helper()
+	client, err := llmprovider.NewClient("openai", hydrate.ProviderConfig{
+		APIKey: getAPIKey(t),
+	})
+	if err != nil {
+		t.Fatalf("creating OpenAI client: %v", err)
+	}
+	return client
+}
+
+// nonStreamingClient wraps an LLMClient to hide the StreamingLLMClient
+// interface, forcing LLMNode to use the synchronous Complete path.
+type nonStreamingClient struct {
+	inner core.LLMClient
+}
+
+func (c *nonStreamingClient) Complete(ctx context.Context, req core.LLMRequest) (core.LLMResponse, error) {
+	return c.inner.Complete(ctx, req)
+}
+
+// newNonStreamingClient returns an LLMClient that does NOT implement
+// StreamingLLMClient, ensuring LLMNode uses the sync path.
+func newNonStreamingClient(t *testing.T) core.LLMClient {
+	t.Helper()
+	return &nonStreamingClient{inner: newOpenAIClient(t)}
+}

--- a/tests/integration/llm_test.go
+++ b/tests/integration/llm_test.go
@@ -1,0 +1,248 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/petalflow/core"
+	"github.com/petal-labs/petalflow/graph"
+	"github.com/petal-labs/petalflow/nodes"
+	"github.com/petal-labs/petalflow/runtime"
+)
+
+func TestLLMNode_NonStreaming(t *testing.T) {
+	skipIfNoAPIKey(t)
+
+	client := newNonStreamingClient(t)
+
+	node := nodes.NewLLMNode("hello", client, nodes.LLMNodeConfig{
+		Model:     "gpt-4o-mini",
+		System:    "You are a helpful assistant. Be very brief.",
+		InputVars: []string{"prompt"},
+		OutputKey: "result",
+		RetryPolicy: core.RetryPolicy{
+			MaxAttempts: 1,
+			Backoff:     0,
+		},
+		Timeout: 30 * time.Second,
+	})
+
+	g, err := graph.NewGraphBuilder("non-streaming-test").
+		AddNode(node).
+		Build()
+	if err != nil {
+		t.Fatalf("building graph: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	env := core.NewEnvelope().WithVar("prompt", "Say hello in one sentence")
+
+	rt := runtime.NewRuntime()
+	result, err := rt.Run(ctx, g, env, runtime.DefaultRunOptions())
+	if err != nil {
+		t.Fatalf("runtime.Run: %v", err)
+	}
+
+	// Check output text
+	output, ok := result.GetVar("result")
+	if !ok {
+		t.Fatal("expected 'result' var in envelope")
+	}
+	text, ok := output.(string)
+	if !ok {
+		t.Fatalf("expected string output, got %T", output)
+	}
+	if text == "" {
+		t.Fatal("expected non-empty output text")
+	}
+	t.Logf("Non-streaming output: %s", text)
+
+	// Check token usage
+	usageVal, ok := result.GetVar("result_usage")
+	if !ok {
+		t.Fatal("expected 'result_usage' var in envelope")
+	}
+	usage, ok := usageVal.(core.TokenUsage)
+	if !ok {
+		t.Fatalf("expected core.TokenUsage, got %T", usageVal)
+	}
+	if usage.TotalTokens == 0 {
+		t.Fatal("expected non-zero total tokens")
+	}
+	t.Logf("Token usage: input=%d output=%d total=%d", usage.InputTokens, usage.OutputTokens, usage.TotalTokens)
+}
+
+func TestLLMNode_Streaming(t *testing.T) {
+	skipIfNoAPIKey(t)
+
+	client := newOpenAIClient(t)
+
+	node := nodes.NewLLMNode("stream-hello", client, nodes.LLMNodeConfig{
+		Model:     "gpt-4o-mini",
+		System:    "You are a helpful assistant. Be very brief.",
+		InputVars: []string{"prompt"},
+		OutputKey: "result",
+		RetryPolicy: core.RetryPolicy{
+			MaxAttempts: 1,
+			Backoff:     0,
+		},
+		Timeout: 30 * time.Second,
+	})
+
+	g, err := graph.NewGraphBuilder("streaming-test").
+		AddNode(node).
+		Build()
+	if err != nil {
+		t.Fatalf("building graph: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	env := core.NewEnvelope().WithVar("prompt", "Say hello in one sentence")
+
+	// Collect events
+	var mu sync.Mutex
+	var deltas []runtime.Event
+	var finals []runtime.Event
+
+	opts := runtime.DefaultRunOptions()
+	opts.EventHandler = func(e runtime.Event) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch e.Kind {
+		case runtime.EventNodeOutputDelta:
+			deltas = append(deltas, e)
+		case runtime.EventNodeOutputFinal:
+			finals = append(finals, e)
+		}
+	}
+
+	rt := runtime.NewRuntime()
+	result, err := rt.Run(ctx, g, env, opts)
+	if err != nil {
+		t.Fatalf("runtime.Run: %v", err)
+	}
+
+	mu.Lock()
+	deltaCount := len(deltas)
+	finalCount := len(finals)
+	mu.Unlock()
+
+	// Assert: at least 1 delta event received
+	if deltaCount == 0 {
+		t.Fatal("expected at least 1 delta event")
+	}
+	t.Logf("Received %d delta events", deltaCount)
+
+	// Assert: exactly 1 final event
+	if finalCount != 1 {
+		t.Fatalf("expected 1 final event, got %d", finalCount)
+	}
+
+	// Assert: final event has non-empty text
+	mu.Lock()
+	finalText, _ := finals[0].Payload["text"].(string)
+	mu.Unlock()
+	if finalText == "" {
+		t.Fatal("expected non-empty text in final event")
+	}
+	t.Logf("Streaming final text: %s", finalText)
+
+	// Assert: output var matches final event text
+	output, ok := result.GetVar("result")
+	if !ok {
+		t.Fatal("expected 'result' var in envelope")
+	}
+	text, ok := output.(string)
+	if !ok {
+		t.Fatalf("expected string output, got %T", output)
+	}
+	if text != finalText {
+		t.Errorf("output var %q does not match final event text %q", text, finalText)
+	}
+}
+
+func TestLLMNode_JSONSchema(t *testing.T) {
+	skipIfNoAPIKey(t)
+
+	client := newNonStreamingClient(t)
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"greeting": map[string]any{
+				"type": "string",
+			},
+		},
+		"required":             []any{"greeting"},
+		"additionalProperties": false,
+	}
+
+	node := nodes.NewLLMNode("json-hello", client, nodes.LLMNodeConfig{
+		Model:      "gpt-4o-mini",
+		System:     "You are a helpful assistant. Respond with a JSON object containing a greeting field.",
+		InputVars:  []string{"prompt"},
+		OutputKey:  "result",
+		JSONSchema: schema,
+		RetryPolicy: core.RetryPolicy{
+			MaxAttempts: 1,
+			Backoff:     0,
+		},
+		Timeout: 30 * time.Second,
+	})
+
+	g, err := graph.NewGraphBuilder("json-schema-test").
+		AddNode(node).
+		Build()
+	if err != nil {
+		t.Fatalf("building graph: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	env := core.NewEnvelope().WithVar("prompt", "Say hello")
+
+	rt := runtime.NewRuntime()
+	result, err := rt.Run(ctx, g, env, runtime.DefaultRunOptions())
+	if err != nil {
+		t.Fatalf("runtime.Run: %v", err)
+	}
+
+	// When JSONSchema is set, the output may be stored as map[string]any (parsed JSON).
+	output, ok := result.GetVar("result")
+	if !ok {
+		t.Fatal("expected 'result' var in envelope")
+	}
+
+	// The output could be map[string]any (if the adapter parsed it) or string.
+	switch v := output.(type) {
+	case map[string]any:
+		greeting, ok := v["greeting"].(string)
+		if !ok || greeting == "" {
+			t.Fatalf("expected non-empty 'greeting' field in JSON output, got: %v", v)
+		}
+		t.Logf("JSON output (parsed): %v", v)
+	case string:
+		// Verify it parses as valid JSON with the expected shape.
+		var parsed map[string]any
+		if err := json.Unmarshal([]byte(v), &parsed); err != nil {
+			t.Fatalf("output is not valid JSON: %v\nraw: %s", err, v)
+		}
+		greeting, ok := parsed["greeting"].(string)
+		if !ok || greeting == "" {
+			t.Fatalf("expected non-empty 'greeting' field, got: %v", parsed)
+		}
+		t.Logf("JSON output (string): %s", v)
+	default:
+		t.Fatalf("unexpected output type %T: %v", output, output)
+	}
+}


### PR DESCRIPTION
## Summary
- Add integration tests exercising real OpenAI API calls through the petalflow stack: LLM nodes (non-streaming, streaming, JSON schema) and embeddings (single + batch)
- Gate tests with `//go:build integration` tag and `OPENAI_API_KEY` env var — excluded from `go test ./...`
- Add GitHub Actions workflow running daily at 2am UTC (+ manual dispatch) with secret verification

## Test plan
- [ ] Verify `go test ./...` does not run integration tests
- [ ] Verify `go test -tags=integration -list '.*' ./tests/integration/...` lists all 5 tests
- [ ] Run locally with `OPENAI_API_KEY=sk-... go test -tags=integration ./tests/integration/... -v -count=1`
- [x] Confirm `CI` environment with `OPENAI_API_KEY` secret is configured in GitHub repo settings
- [ ] Trigger workflow manually via `workflow_dispatch` to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)