### PR TITLE
[codex] Add tool package skeleton and ADR for tool contract boundaries

### DIFF
--- a/docs/adr/0001-tool-package-boundaries.md
+++ b/docs/adr/0001-tool-package-boundaries.md
@@ -1,0 +1,60 @@
+# ADR 0001: Tool Package Boundaries
+
+- Status: Accepted
+- Date: 2026-02-09
+- Related issue: [#24](https://github.com/petal-labs/petalflow/issues/24)
+- Related plan: `/Users/erikhoward/src/github/petal-labs/petalflow/.spec/petalflow-tools-contract-implementation-plan.md` (P1-01)
+
+## Context
+
+PetalFlow needs a tool contract layer that supports native, HTTP, stdio, and MCP-backed tools without leaking transport-specific concerns into compile-time validation and registry operations. The first implementation task requires shipping structure and boundaries before functional behavior.
+
+We need package boundaries that:
+
+1. Keep manifest modeling, registration, invocation, validation, and health concerns separate.
+2. Allow CLI and daemon flows to share the same contract layer.
+3. Avoid locking into transport-specific implementation details in the foundation step.
+
+## Decision
+
+Create a new `tool` package with boundary-specific files and public contracts:
+
+- `manifest.go`: tool/action/config/transport schema models.
+- `registry.go`: registration model and persistence interface for CLI and daemon stores.
+- `adapter.go`: transport-agnostic invocation contract and adapter factory.
+- `native_adapter.go`: in-process adapter skeleton for native tools.
+- `http_adapter.go`: HTTP adapter skeleton.
+- `stdio_adapter.go`: stdio adapter skeleton.
+- `validate.go`: structured diagnostics and validator pipeline interfaces.
+- `health.go`: health status model and probing/monitor interfaces.
+
+The package is intentionally skeletal in this issue. Production behavior (schema validation, persistence, transport IO, retries, health loops) is deferred to follow-up issues in the same implementation plan.
+
+## Dependency Rules
+
+Within the `tool` package, boundaries follow these rules:
+
+1. Manifest types are origin-agnostic and do not depend on adapter or store implementations.
+2. Registry records embed manifests but do not depend on concrete adapters.
+3. Adapters consume registration/manifest data and expose a shared invocation interface.
+4. Validation consumes manifests and registration metadata and returns structured diagnostics.
+5. Health consumes registration context and produces normalized health reports.
+
+## Consequences
+
+Positive:
+
+1. Future tasks can implement each concern incrementally with minimal refactoring.
+2. Compiler/runtime integration can target stable contracts early.
+3. CLI and daemon paths can converge on shared interfaces.
+
+Tradeoffs:
+
+1. Some files currently contain placeholder behavior (`ErrNotImplemented`) until later phase tasks.
+2. Additional ADRs may be needed if we later split this package into subpackages for stricter compile-time dependency enforcement.
+
+## Alternatives Considered
+
+1. Single monolithic implementation in one file: rejected because it blurs boundaries and increases future refactor cost.
+2. Immediate deep subpackage split (`tool/manifest`, `tool/adapter`, etc.): deferred to keep initial API churn low while the contract is still evolving.
+

--- a/tool/adapter.go
+++ b/tool/adapter.go
@@ -1,0 +1,45 @@
+package tool
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	// ErrNotImplemented is returned by placeholder adapters during skeleton phase.
+	ErrNotImplemented = errors.New("tool: not implemented")
+	// ErrActionNotFound indicates the requested action does not exist in a manifest.
+	ErrActionNotFound = errors.New("tool: action not found")
+)
+
+// InvokeRequest is the transport-agnostic invocation payload.
+type InvokeRequest struct {
+	ToolName  string         `json:"tool_name,omitempty"`
+	Action    string         `json:"action"`
+	Inputs    map[string]any `json:"inputs,omitempty"`
+	Config    map[string]any `json:"config,omitempty"`
+	RequestID string         `json:"request_id,omitempty"`
+}
+
+// InvokeResponse is the transport-agnostic invocation result.
+type InvokeResponse struct {
+	Outputs    map[string]any `json:"outputs,omitempty"`
+	DurationMS int64          `json:"duration_ms,omitempty"`
+	Metadata   map[string]any `json:"metadata,omitempty"`
+}
+
+// Adapter hides transport details (native, HTTP, stdio, MCP).
+type Adapter interface {
+	Invoke(ctx context.Context, req InvokeRequest) (InvokeResponse, error)
+	Close(ctx context.Context) error
+}
+
+// AdapterFactory builds adapters from a tool registration.
+type AdapterFactory interface {
+	New(reg Registration) (Adapter, error)
+}
+
+func elapsedMS(start time.Time) int64 {
+	return time.Since(start).Milliseconds()
+}

--- a/tool/doc.go
+++ b/tool/doc.go
@@ -1,0 +1,12 @@
+// Package tool defines the contract boundary for external tool integration.
+//
+// The package is intentionally split by concern:
+//   - manifest: transport-agnostic tool/action schemas
+//   - registry: registration metadata and storage interfaces
+//   - adapter: invocation interface and transport adapters
+//   - validate: validation diagnostics and pipelines
+//   - health: health check status models and probing contracts
+//
+// This package currently provides skeleton interfaces and data models that
+// subsequent implementation tasks will fill in.
+package tool

--- a/tool/health.go
+++ b/tool/health.go
@@ -1,0 +1,37 @@
+package tool
+
+import (
+	"context"
+	"time"
+)
+
+// HealthState indicates the current health of a registered tool.
+type HealthState string
+
+const (
+	HealthUnknown   HealthState = "unknown"
+	HealthHealthy   HealthState = "healthy"
+	HealthUnhealthy HealthState = "unhealthy"
+)
+
+// HealthReport is a normalized health snapshot for a single tool.
+type HealthReport struct {
+	ToolName      string      `json:"tool_name"`
+	State         HealthState `json:"state"`
+	CheckedAt     time.Time   `json:"checked_at"`
+	LatencyMS     int64       `json:"latency_ms,omitempty"`
+	FailureCount  int         `json:"failure_count,omitempty"`
+	ErrorMessage  string      `json:"error_message,omitempty"`
+	DiagnosticRef string      `json:"diagnostic_ref,omitempty"`
+}
+
+// Prober checks the health status of a registration.
+type Prober interface {
+	Probe(ctx context.Context, reg Registration) (HealthReport, error)
+}
+
+// Monitor manages periodic health checks.
+type Monitor interface {
+	Start(ctx context.Context) error
+	Stop(ctx context.Context) error
+}

--- a/tool/http_adapter.go
+++ b/tool/http_adapter.go
@@ -1,0 +1,25 @@
+package tool
+
+import "context"
+
+// HTTPAdapter is the runtime adapter for HTTP-backed tools.
+type HTTPAdapter struct {
+	reg Registration
+}
+
+// NewHTTPAdapter creates an HTTP adapter from a registration.
+func NewHTTPAdapter(reg Registration) *HTTPAdapter {
+	return &HTTPAdapter{reg: reg}
+}
+
+// Invoke executes an action over HTTP.
+//
+// Implementation is intentionally deferred to follow-up tasks.
+func (a *HTTPAdapter) Invoke(ctx context.Context, req InvokeRequest) (InvokeResponse, error) {
+	return InvokeResponse{}, ErrNotImplemented
+}
+
+// Close releases any adapter resources.
+func (a *HTTPAdapter) Close(ctx context.Context) error {
+	return nil
+}

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -1,0 +1,88 @@
+package tool
+
+// Manifest schema constants for the initial tool contract version.
+const (
+	ManifestVersionV1 = "1.0"
+	SchemaToolV1      = "https://petalflow.dev/schemas/tool-manifest/v1.json"
+)
+
+// Manifest describes a registered tool independent of tool origin.
+type Manifest struct {
+	Schema          string                `json:"$schema,omitempty"`
+	ManifestVersion string                `json:"manifest_version"`
+	Tool            ToolInfo              `json:"tool"`
+	Transport       TransportSpec         `json:"transport"`
+	Actions         map[string]ActionSpec `json:"actions"`
+	Config          map[string]FieldSpec  `json:"config,omitempty"`
+	Health          *HealthConfig         `json:"health,omitempty"`
+}
+
+// ToolInfo contains display metadata for a tool.
+type ToolInfo struct {
+	Name        string   `json:"name"`
+	Version     string   `json:"version,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Author      string   `json:"author,omitempty"`
+	License     string   `json:"license,omitempty"`
+	Homepage    string   `json:"homepage,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+}
+
+// ActionSpec defines callable behavior on a tool.
+type ActionSpec struct {
+	Description string               `json:"description,omitempty"`
+	Inputs      map[string]FieldSpec `json:"inputs,omitempty"`
+	Outputs     map[string]FieldSpec `json:"outputs,omitempty"`
+	Idempotent  bool                 `json:"idempotent,omitempty"`
+}
+
+// FieldSpec is the v1 field/type descriptor used for inputs, outputs, and config.
+type FieldSpec struct {
+	Type        string               `json:"type"`
+	Required    bool                 `json:"required,omitempty"`
+	Description string               `json:"description,omitempty"`
+	Default     any                  `json:"default,omitempty"`
+	Sensitive   bool                 `json:"sensitive,omitempty"`
+	Items       *FieldSpec           `json:"items,omitempty"`
+	Properties  map[string]FieldSpec `json:"properties,omitempty"`
+}
+
+// TransportSpec describes how PetalFlow invokes the tool.
+type TransportSpec struct {
+	Type      string         `json:"type"`
+	Endpoint  string         `json:"endpoint,omitempty"`
+	Command   string         `json:"command,omitempty"`
+	Args      []string       `json:"args,omitempty"`
+	Env       map[string]any `json:"env,omitempty"`
+	Mode      string         `json:"mode,omitempty"`
+	TimeoutMS int            `json:"timeout_ms,omitempty"`
+	Retry     RetryPolicy    `json:"retry,omitempty"`
+}
+
+// RetryPolicy defines adapter retry behavior.
+type RetryPolicy struct {
+	MaxAttempts    int   `json:"max_attempts,omitempty"`
+	BackoffMS      int   `json:"backoff_ms,omitempty"`
+	RetryableCodes []int `json:"retryable_codes,omitempty"`
+}
+
+// HealthConfig defines optional tool health-check settings.
+type HealthConfig struct {
+	Endpoint           string `json:"endpoint,omitempty"`
+	Method             string `json:"method,omitempty"`
+	IntervalSeconds    int    `json:"interval_seconds,omitempty"`
+	TimeoutMS          int    `json:"timeout_ms,omitempty"`
+	UnhealthyThreshold int    `json:"unhealthy_threshold,omitempty"`
+}
+
+// NewManifest returns a manifest pre-populated with v1 schema metadata.
+func NewManifest(name string) Manifest {
+	return Manifest{
+		Schema:          SchemaToolV1,
+		ManifestVersion: ManifestVersionV1,
+		Tool: ToolInfo{
+			Name: name,
+		},
+		Actions: make(map[string]ActionSpec),
+	}
+}

--- a/tool/manifest_test.go
+++ b/tool/manifest_test.go
@@ -1,0 +1,44 @@
+package tool
+
+import "testing"
+
+func TestNewManifestDefaults(t *testing.T) {
+	man := NewManifest("s3_fetch")
+
+	if man.Schema != SchemaToolV1 {
+		t.Errorf("Schema = %q, want %q", man.Schema, SchemaToolV1)
+	}
+	if man.ManifestVersion != ManifestVersionV1 {
+		t.Errorf("ManifestVersion = %q, want %q", man.ManifestVersion, ManifestVersionV1)
+	}
+	if man.Tool.Name != "s3_fetch" {
+		t.Errorf("Tool.Name = %q, want %q", man.Tool.Name, "s3_fetch")
+	}
+	if man.Actions == nil {
+		t.Fatal("Actions should be initialized")
+	}
+}
+
+func TestRegistrationActionNamesSorted(t *testing.T) {
+	reg := Registration{
+		Manifest: Manifest{
+			Actions: map[string]ActionSpec{
+				"download": {},
+				"list":     {},
+				"delete":   {},
+			},
+		},
+	}
+
+	got := reg.ActionNames()
+	want := []string{"delete", "download", "list"}
+
+	if len(got) != len(want) {
+		t.Fatalf("len(ActionNames) = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ActionNames[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/tool/native_adapter.go
+++ b/tool/native_adapter.go
@@ -1,0 +1,51 @@
+package tool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// NativeTool is an in-process implementation that can be invoked directly.
+type NativeTool interface {
+	Name() string
+	Manifest() Manifest
+	Invoke(ctx context.Context, action string, inputs map[string]any, config map[string]any) (map[string]any, error)
+}
+
+// NativeAdapter is the in-process adapter for native Go tools.
+type NativeAdapter struct {
+	tool NativeTool
+}
+
+// NewNativeAdapter wraps a NativeTool as a transport adapter.
+func NewNativeAdapter(tool NativeTool) *NativeAdapter {
+	return &NativeAdapter{tool: tool}
+}
+
+// Invoke executes a native tool action in-process.
+func (a *NativeAdapter) Invoke(ctx context.Context, req InvokeRequest) (InvokeResponse, error) {
+	if a == nil || a.tool == nil {
+		return InvokeResponse{}, errors.New("tool: native adapter has no tool")
+	}
+	if req.Action == "" {
+		return InvokeResponse{}, fmt.Errorf("%w: empty action", ErrActionNotFound)
+	}
+
+	start := time.Now()
+	outputs, err := a.tool.Invoke(ctx, req.Action, req.Inputs, req.Config)
+	if err != nil {
+		return InvokeResponse{}, err
+	}
+
+	return InvokeResponse{
+		Outputs:    outputs,
+		DurationMS: elapsedMS(start),
+	}, nil
+}
+
+// Close is a no-op for native tools.
+func (a *NativeAdapter) Close(ctx context.Context) error {
+	return nil
+}

--- a/tool/native_adapter_test.go
+++ b/tool/native_adapter_test.go
@@ -1,0 +1,60 @@
+package tool
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeNativeTool struct {
+	name       string
+	manifest   Manifest
+	wantAction string
+	outputs    map[string]any
+	err        error
+}
+
+func (f fakeNativeTool) Name() string {
+	return f.name
+}
+
+func (f fakeNativeTool) Manifest() Manifest {
+	return f.manifest
+}
+
+func (f fakeNativeTool) Invoke(ctx context.Context, action string, inputs map[string]any, config map[string]any) (map[string]any, error) {
+	if f.wantAction != "" && action != f.wantAction {
+		return nil, errors.New("unexpected action")
+	}
+	return f.outputs, f.err
+}
+
+func TestNativeAdapterInvoke(t *testing.T) {
+	adapter := NewNativeAdapter(fakeNativeTool{
+		name:       "native_test",
+		manifest:   NewManifest("native_test"),
+		wantAction: "list",
+		outputs: map[string]any{
+			"count": 1,
+		},
+	})
+
+	resp, err := adapter.Invoke(context.Background(), InvokeRequest{
+		Action: "list",
+		Inputs: map[string]any{"bucket": "reports"},
+	})
+	if err != nil {
+		t.Fatalf("Invoke returned error: %v", err)
+	}
+	if resp.Outputs["count"] != 1 {
+		t.Errorf("outputs[count] = %v, want 1", resp.Outputs["count"])
+	}
+}
+
+func TestNativeAdapterInvokeNoTool(t *testing.T) {
+	adapter := NewNativeAdapter(nil)
+	_, err := adapter.Invoke(context.Background(), InvokeRequest{Action: "list"})
+	if err == nil {
+		t.Fatal("Invoke error = nil, want non-nil")
+	}
+}

--- a/tool/registry.go
+++ b/tool/registry.go
@@ -1,0 +1,48 @@
+package tool
+
+import (
+	"context"
+	"slices"
+	"time"
+)
+
+// Status indicates registry-level availability of a tool.
+type Status string
+
+const (
+	StatusReady      Status = "ready"
+	StatusUnhealthy  Status = "unhealthy"
+	StatusDisabled   Status = "disabled"
+	StatusUnverified Status = "unverified"
+)
+
+// Registration is the persisted record for a tool instance in the registry.
+type Registration struct {
+	Name        string         `json:"name"`
+	Source      string         `json:"source,omitempty"`
+	Manifest    Manifest       `json:"manifest"`
+	Status      Status         `json:"status"`
+	Enabled     bool           `json:"enabled"`
+	OverlayPath string         `json:"overlay_path,omitempty"`
+	Config      map[string]any `json:"config,omitempty"`
+	CreatedAt   time.Time      `json:"created_at,omitempty"`
+	UpdatedAt   time.Time      `json:"updated_at,omitempty"`
+}
+
+// ActionNames returns registered action names in deterministic order.
+func (r Registration) ActionNames() []string {
+	names := make([]string, 0, len(r.Manifest.Actions))
+	for name := range r.Manifest.Actions {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// Store abstracts persistence for CLI (file) and daemon (service-backed) modes.
+type Store interface {
+	List(ctx context.Context) ([]Registration, error)
+	Get(ctx context.Context, name string) (Registration, bool, error)
+	Upsert(ctx context.Context, reg Registration) error
+	Delete(ctx context.Context, name string) error
+}

--- a/tool/stdio_adapter.go
+++ b/tool/stdio_adapter.go
@@ -1,0 +1,25 @@
+package tool
+
+import "context"
+
+// StdioAdapter is the runtime adapter for subprocess-backed tools.
+type StdioAdapter struct {
+	reg Registration
+}
+
+// NewStdioAdapter creates a stdio adapter from a registration.
+func NewStdioAdapter(reg Registration) *StdioAdapter {
+	return &StdioAdapter{reg: reg}
+}
+
+// Invoke executes an action through a long-running subprocess transport.
+//
+// Implementation is intentionally deferred to follow-up tasks.
+func (a *StdioAdapter) Invoke(ctx context.Context, req InvokeRequest) (InvokeResponse, error) {
+	return InvokeResponse{}, ErrNotImplemented
+}
+
+// Close releases any adapter resources.
+func (a *StdioAdapter) Close(ctx context.Context) error {
+	return nil
+}

--- a/tool/validate.go
+++ b/tool/validate.go
@@ -1,0 +1,76 @@
+package tool
+
+// Severity defines diagnostic severity produced by validators.
+type Severity string
+
+const (
+	SeverityError   Severity = "error"
+	SeverityWarning Severity = "warning"
+)
+
+// Diagnostic is a structured validation finding.
+type Diagnostic struct {
+	Field    string   `json:"field,omitempty"`
+	Code     string   `json:"code,omitempty"`
+	Severity Severity `json:"severity"`
+	Message  string   `json:"message"`
+}
+
+// ManifestValidator validates a tool manifest.
+type ManifestValidator interface {
+	ValidateManifest(manifest Manifest) []Diagnostic
+}
+
+// RegistrationValidator validates a full registration record.
+type RegistrationValidator interface {
+	ValidateRegistration(reg Registration) []Diagnostic
+}
+
+// Result aggregates diagnostics from one or more validation passes.
+type Result struct {
+	Diagnostics []Diagnostic `json:"diagnostics"`
+}
+
+// HasErrors returns true when at least one error-severity diagnostic exists.
+func (r Result) HasErrors() bool {
+	for _, d := range r.Diagnostics {
+		if d.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+// Pipeline composes validators for manifest and registration checks.
+type Pipeline struct {
+	manifestValidators     []ManifestValidator
+	registrationValidators []RegistrationValidator
+}
+
+// AddManifestValidator appends a manifest validator to the pipeline.
+func (p *Pipeline) AddManifestValidator(v ManifestValidator) {
+	p.manifestValidators = append(p.manifestValidators, v)
+}
+
+// AddRegistrationValidator appends a registration validator to the pipeline.
+func (p *Pipeline) AddRegistrationValidator(v RegistrationValidator) {
+	p.registrationValidators = append(p.registrationValidators, v)
+}
+
+// ValidateManifest runs all manifest validators and returns aggregated findings.
+func (p Pipeline) ValidateManifest(manifest Manifest) Result {
+	result := Result{Diagnostics: make([]Diagnostic, 0)}
+	for _, validator := range p.manifestValidators {
+		result.Diagnostics = append(result.Diagnostics, validator.ValidateManifest(manifest)...)
+	}
+	return result
+}
+
+// ValidateRegistration runs all registration validators and returns findings.
+func (p Pipeline) ValidateRegistration(reg Registration) Result {
+	result := Result{Diagnostics: make([]Diagnostic, 0)}
+	for _, validator := range p.registrationValidators {
+		result.Diagnostics = append(result.Diagnostics, validator.ValidateRegistration(reg)...)
+	}
+	return result
+}

--- a/tool/validate_test.go
+++ b/tool/validate_test.go
@@ -1,0 +1,58 @@
+package tool
+
+import "testing"
+
+type stubManifestValidator struct {
+	diags []Diagnostic
+}
+
+func (s stubManifestValidator) ValidateManifest(manifest Manifest) []Diagnostic {
+	return s.diags
+}
+
+type stubRegistrationValidator struct {
+	diags []Diagnostic
+}
+
+func (s stubRegistrationValidator) ValidateRegistration(reg Registration) []Diagnostic {
+	return s.diags
+}
+
+func TestPipelineValidateManifest(t *testing.T) {
+	var p Pipeline
+	p.AddManifestValidator(stubManifestValidator{
+		diags: []Diagnostic{
+			{Severity: SeverityWarning, Message: "warning"},
+		},
+	})
+	p.AddManifestValidator(stubManifestValidator{
+		diags: []Diagnostic{
+			{Severity: SeverityError, Message: "error"},
+		},
+	})
+
+	result := p.ValidateManifest(NewManifest("test_tool"))
+	if len(result.Diagnostics) != 2 {
+		t.Fatalf("diagnostic count = %d, want 2", len(result.Diagnostics))
+	}
+	if !result.HasErrors() {
+		t.Fatal("HasErrors() = false, want true")
+	}
+}
+
+func TestPipelineValidateRegistration(t *testing.T) {
+	var p Pipeline
+	p.AddRegistrationValidator(stubRegistrationValidator{
+		diags: []Diagnostic{
+			{Severity: SeverityWarning, Message: "warning"},
+		},
+	})
+
+	result := p.ValidateRegistration(Registration{Name: "tool_1"})
+	if len(result.Diagnostics) != 1 {
+		t.Fatalf("diagnostic count = %d, want 1", len(result.Diagnostics))
+	}
+	if result.HasErrors() {
+		t.Fatal("HasErrors() = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary
This PR implements issue #24 from the Tool Contract implementation plan (`P1-01`) by introducing the initial `tool` package foundation and documenting package boundaries in an ADR.

The change establishes compile-safe contracts for the tool subsystem so later work can implement behavior incrementally without reworking package structure.

## User Impact
Before this change, PetalFlow had no dedicated contract boundary for external tool integration concerns (manifest modeling, registration, transport abstraction, validation, and health), which made Phase 1 implementation work coupled and harder to evolve safely.

With this change, contributors now have a clear and test-backed foundation to build Phase 1 behavior (`P1-02+`) while keeping CLI/daemon/runtime integration paths aligned.

## Root Cause
The repository did not yet have a dedicated `tool` package and architecture decision record for the FRD-defined boundaries, even though downstream plan tasks depend on those boundaries.

## What Changed
- Added new `tool` package skeleton with explicit boundary files:
  - `tool/manifest.go`
  - `tool/registry.go`
  - `tool/adapter.go`
  - `tool/native_adapter.go`
  - `tool/http_adapter.go`
  - `tool/stdio_adapter.go`
  - `tool/validate.go`
  - `tool/health.go`
  - `tool/doc.go`
- Added boundary-focused tests:
  - `tool/manifest_test.go`
  - `tool/native_adapter_test.go`
  - `tool/validate_test.go`
- Added ADR documenting boundary decisions and dependency rules:
  - `docs/adr/0001-tool-package-boundaries.md`

## Validation
- Ran `gofmt -w tool/*.go tool/*_test.go`
- Ran `GOCACHE=/tmp/petalflow-gocache go test ./tool/...`

## Scope Notes
- This PR is intentionally foundational and does not yet implement transport IO, persistence backends, schema validation engines, or health loops.
- Those behaviors are deferred to follow-up issues in the same implementation plan.

Closes #24
