### PR TITLE
[codex] Implement tool manifest and transport models

### DIFF
--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -1,24 +1,47 @@
 package tool
 
+import "slices"
+
 // Manifest schema constants for the initial tool contract version.
 const (
 	ManifestVersionV1 = "1.0"
 	SchemaToolV1      = "https://petalflow.dev/schemas/tool-manifest/v1.json"
 )
 
-// Manifest describes a registered tool independent of tool origin.
-type Manifest struct {
+// TransportType identifies the runtime transport protocol for a tool.
+type TransportType string
+
+const (
+	TransportTypeHTTP  TransportType = "http"
+	TransportTypeStdio TransportType = "stdio"
+	TransportTypeMCP   TransportType = "mcp"
+)
+
+// MCPMode defines how an MCP server is connected.
+type MCPMode string
+
+const (
+	MCPModeStdio MCPMode = "stdio"
+	MCPModeSSE   MCPMode = "sse"
+)
+
+// ToolManifest describes a registered tool independent of tool origin.
+type ToolManifest struct {
 	Schema          string                `json:"$schema,omitempty"`
 	ManifestVersion string                `json:"manifest_version"`
-	Tool            ToolInfo              `json:"tool"`
+	Tool            ToolMetadata          `json:"tool"`
 	Transport       TransportSpec         `json:"transport"`
 	Actions         map[string]ActionSpec `json:"actions"`
 	Config          map[string]FieldSpec  `json:"config,omitempty"`
 	Health          *HealthConfig         `json:"health,omitempty"`
 }
 
-// ToolInfo contains display metadata for a tool.
-type ToolInfo struct {
+// Manifest is kept as an alias for backward compatibility while the package
+// adopts ToolManifest naming used in the implementation plan.
+type Manifest = ToolManifest
+
+// ToolMetadata contains display metadata for a tool.
+type ToolMetadata struct {
 	Name        string   `json:"name"`
 	Version     string   `json:"version,omitempty"`
 	Description string   `json:"description,omitempty"`
@@ -27,6 +50,9 @@ type ToolInfo struct {
 	Homepage    string   `json:"homepage,omitempty"`
 	Tags        []string `json:"tags,omitempty"`
 }
+
+// ToolInfo is an alias for backward compatibility with previous naming.
+type ToolInfo = ToolMetadata
 
 // ActionSpec defines callable behavior on a tool.
 type ActionSpec struct {
@@ -49,14 +75,41 @@ type FieldSpec struct {
 
 // TransportSpec describes how PetalFlow invokes the tool.
 type TransportSpec struct {
-	Type      string         `json:"type"`
-	Endpoint  string         `json:"endpoint,omitempty"`
-	Command   string         `json:"command,omitempty"`
-	Args      []string       `json:"args,omitempty"`
-	Env       map[string]any `json:"env,omitempty"`
-	Mode      string         `json:"mode,omitempty"`
-	TimeoutMS int            `json:"timeout_ms,omitempty"`
-	Retry     RetryPolicy    `json:"retry,omitempty"`
+	Type      TransportType     `json:"type"`
+	Endpoint  string            `json:"endpoint,omitempty"`
+	Command   string            `json:"command,omitempty"`
+	Args      []string          `json:"args,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+	Mode      MCPMode           `json:"mode,omitempty"`
+	TimeoutMS int               `json:"timeout_ms,omitempty"`
+	Retry     RetryPolicy       `json:"retry,omitempty"`
+}
+
+// HTTPTransport is the typed view for HTTP transport configuration.
+type HTTPTransport struct {
+	Endpoint  string      `json:"endpoint"`
+	TimeoutMS int         `json:"timeout_ms,omitempty"`
+	Retry     RetryPolicy `json:"retry,omitempty"`
+}
+
+// StdioTransport is the typed view for subprocess transport configuration.
+type StdioTransport struct {
+	Command   string            `json:"command"`
+	Args      []string          `json:"args,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+	TimeoutMS int               `json:"timeout_ms,omitempty"`
+	Retry     RetryPolicy       `json:"retry,omitempty"`
+}
+
+// MCPTransport is the typed view for MCP transport configuration.
+type MCPTransport struct {
+	Mode      MCPMode           `json:"mode"`
+	Endpoint  string            `json:"endpoint,omitempty"`
+	Command   string            `json:"command,omitempty"`
+	Args      []string          `json:"args,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
+	TimeoutMS int               `json:"timeout_ms,omitempty"`
+	Retry     RetryPolicy       `json:"retry,omitempty"`
 }
 
 // RetryPolicy defines adapter retry behavior.
@@ -76,13 +129,102 @@ type HealthConfig struct {
 }
 
 // NewManifest returns a manifest pre-populated with v1 schema metadata.
-func NewManifest(name string) Manifest {
-	return Manifest{
+func NewManifest(name string) ToolManifest {
+	return ToolManifest{
 		Schema:          SchemaToolV1,
 		ManifestVersion: ManifestVersionV1,
-		Tool: ToolInfo{
+		Tool: ToolMetadata{
 			Name: name,
 		},
 		Actions: make(map[string]ActionSpec),
 	}
+}
+
+// NewHTTPTransport creates a transport specification for HTTP tools.
+func NewHTTPTransport(cfg HTTPTransport) TransportSpec {
+	return TransportSpec{
+		Type:      TransportTypeHTTP,
+		Endpoint:  cfg.Endpoint,
+		TimeoutMS: cfg.TimeoutMS,
+		Retry:     cfg.Retry,
+	}
+}
+
+// NewStdioTransport creates a transport specification for subprocess tools.
+func NewStdioTransport(cfg StdioTransport) TransportSpec {
+	return TransportSpec{
+		Type:      TransportTypeStdio,
+		Command:   cfg.Command,
+		Args:      slices.Clone(cfg.Args),
+		Env:       cloneStringMap(cfg.Env),
+		TimeoutMS: cfg.TimeoutMS,
+		Retry:     cfg.Retry,
+	}
+}
+
+// NewMCPTransport creates a transport specification for MCP tools.
+func NewMCPTransport(cfg MCPTransport) TransportSpec {
+	return TransportSpec{
+		Type:      TransportTypeMCP,
+		Mode:      cfg.Mode,
+		Endpoint:  cfg.Endpoint,
+		Command:   cfg.Command,
+		Args:      slices.Clone(cfg.Args),
+		Env:       cloneStringMap(cfg.Env),
+		TimeoutMS: cfg.TimeoutMS,
+		Retry:     cfg.Retry,
+	}
+}
+
+// AsHTTP converts a transport specification to HTTP transport config.
+func (t TransportSpec) AsHTTP() (HTTPTransport, bool) {
+	if t.Type != TransportTypeHTTP {
+		return HTTPTransport{}, false
+	}
+	return HTTPTransport{
+		Endpoint:  t.Endpoint,
+		TimeoutMS: t.TimeoutMS,
+		Retry:     t.Retry,
+	}, true
+}
+
+// AsStdio converts a transport specification to stdio transport config.
+func (t TransportSpec) AsStdio() (StdioTransport, bool) {
+	if t.Type != TransportTypeStdio {
+		return StdioTransport{}, false
+	}
+	return StdioTransport{
+		Command:   t.Command,
+		Args:      slices.Clone(t.Args),
+		Env:       cloneStringMap(t.Env),
+		TimeoutMS: t.TimeoutMS,
+		Retry:     t.Retry,
+	}, true
+}
+
+// AsMCP converts a transport specification to MCP transport config.
+func (t TransportSpec) AsMCP() (MCPTransport, bool) {
+	if t.Type != TransportTypeMCP {
+		return MCPTransport{}, false
+	}
+	return MCPTransport{
+		Mode:      t.Mode,
+		Endpoint:  t.Endpoint,
+		Command:   t.Command,
+		Args:      slices.Clone(t.Args),
+		Env:       cloneStringMap(t.Env),
+		TimeoutMS: t.TimeoutMS,
+		Retry:     t.Retry,
+	}, true
+}
+
+func cloneStringMap(in map[string]string) map[string]string {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]string, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
 }

--- a/tool/manifest_test.go
+++ b/tool/manifest_test.go
@@ -1,6 +1,10 @@
 package tool
 
-import "testing"
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
 
 func TestNewManifestDefaults(t *testing.T) {
 	man := NewManifest("s3_fetch")
@@ -21,7 +25,7 @@ func TestNewManifestDefaults(t *testing.T) {
 
 func TestRegistrationActionNamesSorted(t *testing.T) {
 	reg := Registration{
-		Manifest: Manifest{
+		Manifest: ToolManifest{
 			Actions: map[string]ActionSpec{
 				"download": {},
 				"list":     {},
@@ -40,5 +44,139 @@ func TestRegistrationActionNamesSorted(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("ActionNames[%d] = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestToolManifestJSONRoundTrip(t *testing.T) {
+	tests := []struct {
+		name      string
+		transport TransportSpec
+	}{
+		{
+			name: "http",
+			transport: NewHTTPTransport(HTTPTransport{
+				Endpoint:  "http://localhost:9801",
+				TimeoutMS: 30000,
+				Retry: RetryPolicy{
+					MaxAttempts:    3,
+					BackoffMS:      1000,
+					RetryableCodes: []int{429, 502, 503},
+				},
+			}),
+		},
+		{
+			name: "stdio",
+			transport: NewStdioTransport(StdioTransport{
+				Command:   "./pdf_extract",
+				Args:      []string{"--serve"},
+				Env:       map[string]string{"LOG_LEVEL": "warn"},
+				TimeoutMS: 15000,
+			}),
+		},
+		{
+			name: "mcp-stdio",
+			transport: NewMCPTransport(MCPTransport{
+				Mode:    MCPModeStdio,
+				Command: "npx",
+				Args:    []string{"-y", "@acme/s3-mcp-server"},
+			}),
+		},
+		{
+			name: "mcp-sse",
+			transport: NewMCPTransport(MCPTransport{
+				Mode:     MCPModeSSE,
+				Endpoint: "http://localhost:9801/sse",
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			original := ToolManifest{
+				Schema:          SchemaToolV1,
+				ManifestVersion: ManifestVersionV1,
+				Tool: ToolMetadata{
+					Name:        "s3_fetch",
+					Version:     "1.2.0",
+					Description: "S3 operations",
+				},
+				Transport: tt.transport,
+				Actions: map[string]ActionSpec{
+					"list": {
+						Description: "List objects",
+						Inputs: map[string]FieldSpec{
+							"bucket": {Type: "string", Required: true},
+							"prefix": {Type: "string", Default: ""},
+						},
+						Outputs: map[string]FieldSpec{
+							"keys": {
+								Type: "array",
+								Items: &FieldSpec{
+									Type: "string",
+								},
+							},
+						},
+						Idempotent: true,
+					},
+				},
+				Config: map[string]FieldSpec{
+					"credentials": {
+						Type:      "string",
+						Required:  true,
+						Sensitive: true,
+					},
+				},
+				Health: &HealthConfig{
+					Endpoint:           "/health",
+					Method:             "GET",
+					IntervalSeconds:    30,
+					TimeoutMS:          5000,
+					UnhealthyThreshold: 3,
+				},
+			}
+
+			raw, err := json.Marshal(original)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			var decoded ToolManifest
+			if err := json.Unmarshal(raw, &decoded); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+
+			if !reflect.DeepEqual(decoded, original) {
+				t.Fatalf("round-trip mismatch:\n got: %#v\nwant: %#v", decoded, original)
+			}
+		})
+	}
+}
+
+func TestTransportTypedViews(t *testing.T) {
+	httpSpec := NewHTTPTransport(HTTPTransport{Endpoint: "http://localhost:9801"})
+	httpCfg, ok := httpSpec.AsHTTP()
+	if !ok {
+		t.Fatal("AsHTTP() ok = false, want true")
+	}
+	if httpCfg.Endpoint != "http://localhost:9801" {
+		t.Errorf("AsHTTP().Endpoint = %q, want %q", httpCfg.Endpoint, "http://localhost:9801")
+	}
+	if _, ok := httpSpec.AsMCP(); ok {
+		t.Fatal("AsMCP() ok = true, want false for HTTP transport")
+	}
+
+	mcpSpec := NewMCPTransport(MCPTransport{
+		Mode:     MCPModeSSE,
+		Endpoint: "http://localhost:9801/sse",
+	})
+	mcpCfg, ok := mcpSpec.AsMCP()
+	if !ok {
+		t.Fatal("AsMCP() ok = false, want true")
+	}
+	if mcpCfg.Mode != MCPModeSSE {
+		t.Errorf("AsMCP().Mode = %q, want %q", mcpCfg.Mode, MCPModeSSE)
+	}
+	if _, ok := mcpSpec.AsStdio(); ok {
+		t.Fatal("AsStdio() ok = true, want false for MCP transport")
 	}
 }


### PR DESCRIPTION
## Summary
Implements issue #25 (`P1-02`) from the Tool Contract implementation plan by expanding the manifest model and transport definitions to align with FRD v1.0 requirements, while preserving compatibility with the existing `tool` package surface introduced in #24.

## What changed
- Added explicit `ToolManifest` naming and kept compatibility aliasing (`type Manifest = ToolManifest`).
- Added explicit metadata naming (`ToolMetadata`) with compatibility alias (`type ToolInfo = ToolMetadata`).
- Added typed transport enums/constants:
  - `TransportType` (`http`, `stdio`, `mcp`)
  - `MCPMode` (`stdio`, `sse`)
- Expanded `TransportSpec` typing and env handling to `map[string]string`.
- Added concrete transport config structs:
  - `HTTPTransport`
  - `StdioTransport`
  - `MCPTransport`
- Added transport helpers:
  - constructors: `NewHTTPTransport`, `NewStdioTransport`, `NewMCPTransport`
  - typed views: `AsHTTP`, `AsStdio`, `AsMCP`
- Added and expanded tests for JSON round-trip and transport typing behavior in `tool/manifest_test.go`.

## Why
Issue #25 requires the manifest model to compile and round-trip JSON for v1 contract structures, including HTTP/stdio/MCP transport placeholders. This PR establishes those typed models and verifies round-tripping across transport variants.

## Validation
- `gofmt -w tool/manifest.go tool/manifest_test.go`
- `GOCACHE=/tmp/petalflow-gocache go test ./tool/...`

Closes #25
