### PR TITLE
[codex] Implement v1 type system validator with source/target diagnostics

### DIFF
--- a/tool/type_system.go
+++ b/tool/type_system.go
@@ -1,0 +1,233 @@
+package tool
+
+import (
+	"fmt"
+	"slices"
+)
+
+// V1 type system literals used by tool manifests.
+const (
+	TypeString  = "string"
+	TypeInteger = "integer"
+	TypeFloat   = "float"
+	TypeBoolean = "boolean"
+	TypeBytes   = "bytes"
+	TypeArray   = "array"
+	TypeObject  = "object"
+	TypeAny     = "any"
+)
+
+var validV1Types = map[string]struct{}{
+	TypeString:  {},
+	TypeInteger: {},
+	TypeFloat:   {},
+	TypeBoolean: {},
+	TypeBytes:   {},
+	TypeArray:   {},
+	TypeObject:  {},
+	TypeAny:     {},
+}
+
+// V1TypeSystemValidator validates field declarations and type compatibility.
+type V1TypeSystemValidator struct{}
+
+// ValidateManifestTypes validates all type declarations in a manifest.
+func (V1TypeSystemValidator) ValidateManifestTypes(manifest Manifest) []Diagnostic {
+	diags := make([]Diagnostic, 0)
+
+	for _, actionName := range sortedActionNames(manifest.Actions) {
+		action := manifest.Actions[actionName]
+		for _, inputName := range sortedFieldNames(action.Inputs) {
+			validateFieldSpec("actions."+actionName+".inputs."+inputName, action.Inputs[inputName], &diags)
+		}
+		for _, outputName := range sortedFieldNames(action.Outputs) {
+			validateFieldSpec("actions."+actionName+".outputs."+outputName, action.Outputs[outputName], &diags)
+		}
+	}
+
+	for _, configName := range sortedFieldNames(manifest.Config) {
+		validateFieldSpec("config."+configName, manifest.Config[configName], &diags)
+	}
+
+	return diags
+}
+
+// ValidateCompatibility validates a source output field against a target input field.
+//
+// When either side is typed as "any", compatibility is allowed but returns a warning.
+func (V1TypeSystemValidator) ValidateCompatibility(sourceField string, sourceSpec FieldSpec, targetField string, targetSpec FieldSpec) []Diagnostic {
+	diags := make([]Diagnostic, 0)
+	validateCompatibility(sourceField, sourceSpec, targetField, targetSpec, &diags)
+	return diags
+}
+
+func validateFieldSpec(path string, spec FieldSpec, diags *[]Diagnostic) {
+	if !isValidV1Type(spec.Type) {
+		*diags = append(*diags, Diagnostic{
+			Field:    path + ".type",
+			Code:     "INVALID_TYPE",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("Unsupported type %q; allowed: string, integer, float, boolean, bytes, array, object, any", spec.Type),
+		})
+		return
+	}
+
+	if spec.Type == TypeArray {
+		if spec.Items == nil {
+			*diags = append(*diags, Diagnostic{
+				Field:    path + ".items",
+				Code:     "REQUIRED_ITEMS",
+				Severity: SeverityError,
+				Message:  "items is required when type is array",
+			})
+			return
+		}
+		validateFieldSpec(path+".items", *spec.Items, diags)
+	}
+
+	for _, name := range sortedFieldNames(spec.Properties) {
+		validateFieldSpec(path+".properties."+name, spec.Properties[name], diags)
+	}
+}
+
+func validateCompatibility(sourceField string, sourceSpec FieldSpec, targetField string, targetSpec FieldSpec, diags *[]Diagnostic) {
+	sourceType := sourceSpec.Type
+	targetType := targetSpec.Type
+
+	if !isValidV1Type(sourceType) {
+		*diags = append(*diags, Diagnostic{
+			Field:       sourceField + ".type",
+			SourceField: sourceField,
+			TargetField: targetField,
+			SourceType:  sourceType,
+			TargetType:  targetType,
+			Code:        "INVALID_SOURCE_TYPE",
+			Severity:    SeverityError,
+			Message:     fmt.Sprintf("Source field has unsupported type %q", sourceType),
+		})
+		return
+	}
+
+	if !isValidV1Type(targetType) {
+		*diags = append(*diags, Diagnostic{
+			Field:       targetField + ".type",
+			SourceField: sourceField,
+			TargetField: targetField,
+			SourceType:  sourceType,
+			TargetType:  targetType,
+			Code:        "INVALID_TARGET_TYPE",
+			Severity:    SeverityError,
+			Message:     fmt.Sprintf("Target field has unsupported type %q", targetType),
+		})
+		return
+	}
+
+	if sourceType == TypeAny || targetType == TypeAny {
+		*diags = append(*diags, Diagnostic{
+			Field:       targetField,
+			SourceField: sourceField,
+			TargetField: targetField,
+			SourceType:  sourceType,
+			TargetType:  targetType,
+			Code:        "TYPE_ANY_BYPASS",
+			Severity:    SeverityWarning,
+			Message:     "Type compatibility check bypassed because one side is typed as any",
+		})
+		return
+	}
+
+	if sourceType != targetType {
+		*diags = append(*diags, Diagnostic{
+			Field:       targetField,
+			SourceField: sourceField,
+			TargetField: targetField,
+			SourceType:  sourceType,
+			TargetType:  targetType,
+			Code:        "TYPE_MISMATCH",
+			Severity:    SeverityError,
+			Message:     fmt.Sprintf("Type mismatch: source %q (%s) is not compatible with target %q (%s)", sourceField, sourceType, targetField, targetType),
+		})
+		return
+	}
+
+	switch sourceType {
+	case TypeArray:
+		if sourceSpec.Items == nil {
+			*diags = append(*diags, Diagnostic{
+				Field:       sourceField + ".items",
+				SourceField: sourceField,
+				TargetField: targetField,
+				SourceType:  sourceType,
+				TargetType:  targetType,
+				Code:        "ARRAY_ITEMS_REQUIRED",
+				Severity:    SeverityError,
+				Message:     "Source array type must define items",
+			})
+			return
+		}
+		if targetSpec.Items == nil {
+			*diags = append(*diags, Diagnostic{
+				Field:       targetField + ".items",
+				SourceField: sourceField,
+				TargetField: targetField,
+				SourceType:  sourceType,
+				TargetType:  targetType,
+				Code:        "ARRAY_ITEMS_REQUIRED",
+				Severity:    SeverityError,
+				Message:     "Target array type must define items",
+			})
+			return
+		}
+		validateCompatibility(sourceField+"[]", *sourceSpec.Items, targetField+"[]", *targetSpec.Items, diags)
+	case TypeObject:
+		// Generic object type: no declared properties on either side.
+		if len(sourceSpec.Properties) == 0 || len(targetSpec.Properties) == 0 {
+			return
+		}
+		for _, propName := range sortedFieldNames(targetSpec.Properties) {
+			targetProp := targetSpec.Properties[propName]
+			sourceProp, ok := sourceSpec.Properties[propName]
+			propSourceField := sourceField + "." + propName
+			propTargetField := targetField + "." + propName
+			if !ok {
+				if targetProp.Required {
+					*diags = append(*diags, Diagnostic{
+						Field:       propTargetField,
+						SourceField: sourceField,
+						TargetField: propTargetField,
+						SourceType:  sourceType,
+						TargetType:  targetProp.Type,
+						Code:        "OBJECT_PROPERTY_MISSING",
+						Severity:    SeverityError,
+						Message:     fmt.Sprintf("Target requires property %q which is missing from source object", propName),
+					})
+				}
+				continue
+			}
+			validateCompatibility(propSourceField, sourceProp, propTargetField, targetProp, diags)
+		}
+	}
+}
+
+func isValidV1Type(typeName string) bool {
+	_, ok := validV1Types[typeName]
+	return ok
+}
+
+func sortedActionNames(actions map[string]ActionSpec) []string {
+	names := make([]string, 0, len(actions))
+	for name := range actions {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func sortedFieldNames(fields map[string]FieldSpec) []string {
+	names := make([]string, 0, len(fields))
+	for name := range fields {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}

--- a/tool/type_system_test.go
+++ b/tool/type_system_test.go
@@ -1,0 +1,182 @@
+package tool
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestV1TypeSystemValidatorValidateManifestTypes(t *testing.T) {
+	validator := V1TypeSystemValidator{}
+	manifest := NewManifest("type_test")
+	manifest.Actions["list"] = ActionSpec{
+		Inputs: map[string]FieldSpec{
+			"bucket": {Type: TypeString, Required: true},
+			"bad":    {Type: "uuid"},
+		},
+		Outputs: map[string]FieldSpec{
+			"keys": {
+				Type: TypeArray,
+				Items: &FieldSpec{
+					Type: TypeString,
+				},
+			},
+			"broken_array": {
+				Type: TypeArray,
+			},
+		},
+	}
+	manifest.Config = map[string]FieldSpec{
+		"meta": {
+			Type: TypeObject,
+			Properties: map[string]FieldSpec{
+				"attempts": {Type: TypeInteger},
+				"bad_prop": {Type: "number"},
+			},
+		},
+	}
+
+	diags := validator.ValidateManifestTypes(manifest)
+	fields := diagnosticFields(diags)
+
+	expect := []string{
+		"actions.list.inputs.bad.type",
+		"actions.list.outputs.broken_array.items",
+		"config.meta.properties.bad_prop.type",
+	}
+	for _, field := range expect {
+		if !slices.Contains(fields, field) {
+			t.Fatalf("expected diagnostic on %q, got: %v", field, fields)
+		}
+	}
+}
+
+func TestV1TypeSystemValidatorCompatibilityMismatchIncludesSourceTarget(t *testing.T) {
+	validator := V1TypeSystemValidator{}
+	diags := validator.ValidateCompatibility(
+		"actions.src.outputs.count",
+		FieldSpec{Type: TypeInteger},
+		"actions.dst.inputs.count",
+		FieldSpec{Type: TypeString},
+	)
+
+	if len(diags) != 1 {
+		t.Fatalf("diagnostic count = %d, want 1", len(diags))
+	}
+	diag := diags[0]
+	if diag.Code != "TYPE_MISMATCH" {
+		t.Fatalf("Code = %q, want TYPE_MISMATCH", diag.Code)
+	}
+	if diag.SourceField != "actions.src.outputs.count" {
+		t.Fatalf("SourceField = %q, want actions.src.outputs.count", diag.SourceField)
+	}
+	if diag.TargetField != "actions.dst.inputs.count" {
+		t.Fatalf("TargetField = %q, want actions.dst.inputs.count", diag.TargetField)
+	}
+	if diag.SourceType != TypeInteger || diag.TargetType != TypeString {
+		t.Fatalf("SourceType/TargetType = (%q,%q), want (%q,%q)", diag.SourceType, diag.TargetType, TypeInteger, TypeString)
+	}
+}
+
+func TestV1TypeSystemValidatorCompatibilityAnyProducesWarning(t *testing.T) {
+	validator := V1TypeSystemValidator{}
+	diags := validator.ValidateCompatibility(
+		"actions.src.outputs.result",
+		FieldSpec{Type: TypeAny},
+		"actions.dst.inputs.result",
+		FieldSpec{Type: TypeObject},
+	)
+
+	if len(diags) != 1 {
+		t.Fatalf("diagnostic count = %d, want 1", len(diags))
+	}
+	if diags[0].Severity != SeverityWarning {
+		t.Fatalf("Severity = %q, want %q", diags[0].Severity, SeverityWarning)
+	}
+	if diags[0].Code != "TYPE_ANY_BYPASS" {
+		t.Fatalf("Code = %q, want TYPE_ANY_BYPASS", diags[0].Code)
+	}
+}
+
+func TestV1TypeSystemValidatorCompatibilityArrayNested(t *testing.T) {
+	validator := V1TypeSystemValidator{}
+	source := FieldSpec{
+		Type: TypeArray,
+		Items: &FieldSpec{
+			Type: TypeString,
+		},
+	}
+
+	targetOK := FieldSpec{
+		Type: TypeArray,
+		Items: &FieldSpec{
+			Type: TypeString,
+		},
+	}
+	if diags := validator.ValidateCompatibility("src.keys", source, "dst.keys", targetOK); len(diags) != 0 {
+		t.Fatalf("expected no diagnostics, got: %#v", diags)
+	}
+
+	targetBad := FieldSpec{
+		Type: TypeArray,
+		Items: &FieldSpec{
+			Type: TypeInteger,
+		},
+	}
+	diags := validator.ValidateCompatibility("src.keys", source, "dst.keys", targetBad)
+	if len(diags) == 0 {
+		t.Fatal("expected mismatch diagnostics for array item type mismatch")
+	}
+	if diags[0].Code != "TYPE_MISMATCH" {
+		t.Fatalf("Code = %q, want TYPE_MISMATCH", diags[0].Code)
+	}
+	if diags[0].SourceField != "src.keys[]" || diags[0].TargetField != "dst.keys[]" {
+		t.Fatalf("source/target fields = (%q, %q), want (src.keys[], dst.keys[])", diags[0].SourceField, diags[0].TargetField)
+	}
+}
+
+func TestV1TypeSystemValidatorCompatibilityObjectProperties(t *testing.T) {
+	validator := V1TypeSystemValidator{}
+	source := FieldSpec{
+		Type: TypeObject,
+		Properties: map[string]FieldSpec{
+			"name": {Type: TypeString, Required: true},
+		},
+	}
+	target := FieldSpec{
+		Type: TypeObject,
+		Properties: map[string]FieldSpec{
+			"name": {Type: TypeString, Required: true},
+			"age":  {Type: TypeInteger, Required: true},
+		},
+	}
+
+	diags := validator.ValidateCompatibility("src.user", source, "dst.user", target)
+	if len(diags) != 1 {
+		t.Fatalf("diagnostic count = %d, want 1", len(diags))
+	}
+	if diags[0].Code != "OBJECT_PROPERTY_MISSING" {
+		t.Fatalf("Code = %q, want OBJECT_PROPERTY_MISSING", diags[0].Code)
+	}
+	if diags[0].TargetField != "dst.user.age" {
+		t.Fatalf("TargetField = %q, want dst.user.age", diags[0].TargetField)
+	}
+}
+
+func TestV1TypeSystemValidatorCompatibilityInvalidType(t *testing.T) {
+	validator := V1TypeSystemValidator{}
+	diags := validator.ValidateCompatibility(
+		"src.value",
+		FieldSpec{Type: "uuid"},
+		"dst.value",
+		FieldSpec{Type: TypeString},
+	)
+	if len(diags) != 1 {
+		t.Fatalf("diagnostic count = %d, want 1", len(diags))
+	}
+	if diags[0].Code != "INVALID_SOURCE_TYPE" {
+		t.Fatalf("Code = %q, want INVALID_SOURCE_TYPE", diags[0].Code)
+	}
+	if diags[0].Field != "src.value.type" {
+		t.Fatalf("Field = %q, want src.value.type", diags[0].Field)
+	}
+}

--- a/tool/validate.go
+++ b/tool/validate.go
@@ -10,10 +10,14 @@ const (
 
 // Diagnostic is a structured validation finding.
 type Diagnostic struct {
-	Field    string   `json:"field,omitempty"`
-	Code     string   `json:"code,omitempty"`
-	Severity Severity `json:"severity"`
-	Message  string   `json:"message"`
+	Field       string   `json:"field,omitempty"`
+	SourceField string   `json:"source_field,omitempty"`
+	TargetField string   `json:"target_field,omitempty"`
+	SourceType  string   `json:"source_type,omitempty"`
+	TargetType  string   `json:"target_type,omitempty"`
+	Code        string   `json:"code,omitempty"`
+	Severity    Severity `json:"severity"`
+	Message     string   `json:"message"`
 }
 
 // ManifestValidator validates a tool manifest.


### PR DESCRIPTION
## Summary
Implements issue #27 (`P1-04`) by adding a dedicated v1 type-system validator for tool manifests and field compatibility checks across the allowed type set:
- `string`
- `integer`
- `float`
- `boolean`
- `bytes`
- `array`
- `object`
- `any`

## What changed
- Added `tool/type_system.go` with `V1TypeSystemValidator`:
  - `ValidateManifestTypes(manifest)` validates declared field types in action inputs/outputs and config.
  - `ValidateCompatibility(sourceField, sourceSpec, targetField, targetSpec)` validates source/target wiring compatibility.
- Added compatibility behavior for FRD-aligned cases:
  - strict mismatch detection for incompatible source/target types
  - recursive array item compatibility
  - object property compatibility with required target-property checks
  - `any` compatibility bypass with warning
- Extended diagnostics payload in `tool/validate.go` to include:
  - `source_field`, `target_field`
  - `source_type`, `target_type`

## Why
The implementation plan requires type mismatch diagnostics to reference both source and target fields. This PR introduces explicit source/target-aware diagnostics and a reusable validator API for upcoming compile-time wiring checks.

## Validation
- `gofmt -w tool/validate.go tool/type_system.go tool/type_system_test.go`
- `GOCACHE=/tmp/petalflow-gocache go test ./tool/...`
- `GOCACHE=/tmp/petalflow-gocache gosec -exclude-dir=examples -exclude-dir=irisadapter ./tool/...`

Closes #27
