### PR TITLE
[codex] Implement tool registration model and CLI/daemon store abstractions

### DIFF
--- a/tool/registry.go
+++ b/tool/registry.go
@@ -16,21 +16,40 @@ const (
 	StatusUnverified Status = "unverified"
 )
 
-// Registration is the persisted record for a tool instance in the registry.
-type Registration struct {
-	Name        string         `json:"name"`
-	Source      string         `json:"source,omitempty"`
-	Manifest    Manifest       `json:"manifest"`
-	Status      Status         `json:"status"`
-	Enabled     bool           `json:"enabled"`
-	OverlayPath string         `json:"overlay_path,omitempty"`
-	Config      map[string]any `json:"config,omitempty"`
-	CreatedAt   time.Time      `json:"created_at,omitempty"`
-	UpdatedAt   time.Time      `json:"updated_at,omitempty"`
+// ToolOrigin indicates how a tool is integrated into PetalFlow.
+type ToolOrigin string
+
+const (
+	OriginNative ToolOrigin = "native"
+	OriginMCP    ToolOrigin = "mcp"
+	OriginHTTP   ToolOrigin = "http"
+	OriginStdio  ToolOrigin = "stdio"
+)
+
+// ToolOverlay contains optional overlay metadata used for MCP tools.
+type ToolOverlay struct {
+	Path string `json:"path,omitempty"`
 }
 
+// ToolRegistration is the persisted record for a tool instance in the registry.
+type ToolRegistration struct {
+	Name            string            `json:"name"`
+	Manifest        ToolManifest      `json:"manifest"`
+	Origin          ToolOrigin        `json:"origin,omitempty"`
+	Config          map[string]string `json:"config,omitempty"`
+	Status          Status            `json:"status"`
+	RegisteredAt    time.Time         `json:"registered_at,omitempty"`
+	LastHealthCheck time.Time         `json:"last_health_check,omitempty"`
+	Overlay         *ToolOverlay      `json:"overlay,omitempty"`
+	Enabled         bool              `json:"enabled,omitempty"`
+}
+
+// Registration is kept as an alias for backward compatibility while the package
+// adopts ToolRegistration naming used in the implementation plan.
+type Registration = ToolRegistration
+
 // ActionNames returns registered action names in deterministic order.
-func (r Registration) ActionNames() []string {
+func (r ToolRegistration) ActionNames() []string {
 	names := make([]string, 0, len(r.Manifest.Actions))
 	for name := range r.Manifest.Actions {
 		names = append(names, name)
@@ -41,8 +60,8 @@ func (r Registration) ActionNames() []string {
 
 // Store abstracts persistence for CLI (file) and daemon (service-backed) modes.
 type Store interface {
-	List(ctx context.Context) ([]Registration, error)
-	Get(ctx context.Context, name string) (Registration, bool, error)
-	Upsert(ctx context.Context, reg Registration) error
+	List(ctx context.Context) ([]ToolRegistration, error)
+	Get(ctx context.Context, name string) (ToolRegistration, bool, error)
+	Upsert(ctx context.Context, reg ToolRegistration) error
 	Delete(ctx context.Context, name string) error
 }

--- a/tool/store_daemon.go
+++ b/tool/store_daemon.go
@@ -1,0 +1,61 @@
+package tool
+
+import (
+	"context"
+	"errors"
+)
+
+var errNilDaemonBackend = errors.New("tool: daemon backend is nil")
+
+// DaemonRegistryBackend represents the server-side persistence contract for tools.
+// It allows the same ToolRegistration model to be used in daemon/API paths.
+type DaemonRegistryBackend interface {
+	ListToolRegistrations(ctx context.Context) ([]ToolRegistration, error)
+	GetToolRegistration(ctx context.Context, name string) (ToolRegistration, bool, error)
+	UpsertToolRegistration(ctx context.Context, reg ToolRegistration) error
+	DeleteToolRegistration(ctx context.Context, name string) error
+}
+
+// DaemonStore adapts a daemon backend to the shared Store interface.
+type DaemonStore struct {
+	backend DaemonRegistryBackend
+}
+
+// NewDaemonStore creates a Store backed by daemon persistence.
+func NewDaemonStore(backend DaemonRegistryBackend) *DaemonStore {
+	return &DaemonStore{backend: backend}
+}
+
+// List returns all tool registrations from daemon persistence.
+func (s *DaemonStore) List(ctx context.Context) ([]ToolRegistration, error) {
+	if s == nil || s.backend == nil {
+		return nil, errNilDaemonBackend
+	}
+	return s.backend.ListToolRegistrations(ctx)
+}
+
+// Get returns a tool registration by name from daemon persistence.
+func (s *DaemonStore) Get(ctx context.Context, name string) (ToolRegistration, bool, error) {
+	if s == nil || s.backend == nil {
+		return ToolRegistration{}, false, errNilDaemonBackend
+	}
+	return s.backend.GetToolRegistration(ctx, name)
+}
+
+// Upsert inserts or updates a tool registration in daemon persistence.
+func (s *DaemonStore) Upsert(ctx context.Context, reg ToolRegistration) error {
+	if s == nil || s.backend == nil {
+		return errNilDaemonBackend
+	}
+	return s.backend.UpsertToolRegistration(ctx, reg)
+}
+
+// Delete removes a tool registration from daemon persistence.
+func (s *DaemonStore) Delete(ctx context.Context, name string) error {
+	if s == nil || s.backend == nil {
+		return errNilDaemonBackend
+	}
+	return s.backend.DeleteToolRegistration(ctx, name)
+}
+
+var _ Store = (*DaemonStore)(nil)

--- a/tool/store_daemon_test.go
+++ b/tool/store_daemon_test.go
@@ -1,0 +1,105 @@
+package tool
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+type fakeDaemonBackend struct {
+	regs map[string]ToolRegistration
+}
+
+func newFakeDaemonBackend() *fakeDaemonBackend {
+	return &fakeDaemonBackend{
+		regs: make(map[string]ToolRegistration),
+	}
+}
+
+func (f *fakeDaemonBackend) ListToolRegistrations(ctx context.Context) ([]ToolRegistration, error) {
+	out := make([]ToolRegistration, 0, len(f.regs))
+	for _, reg := range f.regs {
+		out = append(out, reg)
+	}
+	return out, nil
+}
+
+func (f *fakeDaemonBackend) GetToolRegistration(ctx context.Context, name string) (ToolRegistration, bool, error) {
+	reg, ok := f.regs[name]
+	return reg, ok, nil
+}
+
+func (f *fakeDaemonBackend) UpsertToolRegistration(ctx context.Context, reg ToolRegistration) error {
+	f.regs[reg.Name] = reg
+	return nil
+}
+
+func (f *fakeDaemonBackend) DeleteToolRegistration(ctx context.Context, name string) error {
+	delete(f.regs, name)
+	return nil
+}
+
+func TestDaemonStoreNilBackend(t *testing.T) {
+	store := NewDaemonStore(nil)
+	if _, err := store.List(context.Background()); !errors.Is(err, errNilDaemonBackend) {
+		t.Fatalf("List() error = %v, want errNilDaemonBackend", err)
+	}
+	if _, _, err := store.Get(context.Background(), "x"); !errors.Is(err, errNilDaemonBackend) {
+		t.Fatalf("Get() error = %v, want errNilDaemonBackend", err)
+	}
+	if err := store.Upsert(context.Background(), ToolRegistration{Name: "x"}); !errors.Is(err, errNilDaemonBackend) {
+		t.Fatalf("Upsert() error = %v, want errNilDaemonBackend", err)
+	}
+	if err := store.Delete(context.Background(), "x"); !errors.Is(err, errNilDaemonBackend) {
+		t.Fatalf("Delete() error = %v, want errNilDaemonBackend", err)
+	}
+}
+
+func TestDaemonStoreCRUD(t *testing.T) {
+	backend := newFakeDaemonBackend()
+	store := NewDaemonStore(backend)
+	ctx := context.Background()
+
+	reg := ToolRegistration{
+		Name:     "http_fetch",
+		Origin:   OriginHTTP,
+		Manifest: NewManifest("http_fetch"),
+		Status:   StatusReady,
+	}
+	reg.Manifest.Transport = NewHTTPTransport(HTTPTransport{Endpoint: "http://localhost:9999"})
+
+	if err := store.Upsert(ctx, reg); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	got, ok, err := store.Get(ctx, "http_fetch")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("Get() ok = false, want true")
+	}
+	if got.Name != "http_fetch" {
+		t.Fatalf("Get().Name = %q, want http_fetch", got.Name)
+	}
+
+	list, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("len(List()) = %d, want 1", len(list))
+	}
+
+	if err := store.Delete(ctx, "http_fetch"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	_, ok, err = store.Get(ctx, "http_fetch")
+	if err != nil {
+		t.Fatalf("Get() after delete error = %v", err)
+	}
+	if ok {
+		t.Fatal("Get() after delete ok = true, want false")
+	}
+}

--- a/tool/store_file.go
+++ b/tool/store_file.go
@@ -1,0 +1,277 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	fileStoreVersionV1 = "1"
+	defaultCLIStoreDir = ".petalflow"
+	defaultCLIStoreDB  = "tools.json"
+)
+
+var errEmptyStorePath = errors.New("tool: file store path is empty")
+
+type fileStoreDocument struct {
+	Version string             `json:"version"`
+	Tools   []ToolRegistration `json:"tools"`
+}
+
+// FileStore persists tool registrations in a local JSON file.
+// This store is intended for CLI mode.
+type FileStore struct {
+	path string
+	mu   sync.RWMutex
+}
+
+// NewFileStore creates a file-backed registration store at the given path.
+func NewFileStore(path string) *FileStore {
+	return &FileStore{path: path}
+}
+
+// NewDefaultFileStore creates a CLI store at ~/.petalflow/tools.json.
+func NewDefaultFileStore() (*FileStore, error) {
+	path, err := DefaultCLIStorePath()
+	if err != nil {
+		return nil, err
+	}
+	return NewFileStore(path), nil
+}
+
+// DefaultCLIStorePath returns the default registration file path for CLI mode.
+func DefaultCLIStorePath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("tool: resolve user home: %w", err)
+	}
+	return filepath.Join(home, defaultCLIStoreDir, defaultCLIStoreDB), nil
+}
+
+// Path returns the backing file path.
+func (s *FileStore) Path() string {
+	if s == nil {
+		return ""
+	}
+	return s.path
+}
+
+// List returns all registrations in deterministic (name-sorted) order.
+func (s *FileStore) List(ctx context.Context) ([]ToolRegistration, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if s == nil {
+		return nil, errors.New("tool: file store is nil")
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	regs, err := s.load()
+	if err != nil {
+		return nil, err
+	}
+	return cloneRegistrations(regs), nil
+}
+
+// Get returns a registration by name.
+func (s *FileStore) Get(ctx context.Context, name string) (ToolRegistration, bool, error) {
+	if err := ctx.Err(); err != nil {
+		return ToolRegistration{}, false, err
+	}
+
+	regs, err := s.List(ctx)
+	if err != nil {
+		return ToolRegistration{}, false, err
+	}
+
+	for _, reg := range regs {
+		if reg.Name == name {
+			return reg, true, nil
+		}
+	}
+	return ToolRegistration{}, false, nil
+}
+
+// Upsert inserts or updates a registration by name.
+func (s *FileStore) Upsert(ctx context.Context, reg ToolRegistration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if s == nil {
+		return errors.New("tool: file store is nil")
+	}
+	if strings.TrimSpace(reg.Name) == "" {
+		return errors.New("tool: registration name is required")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	regs, err := s.load()
+	if err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	index := -1
+	for i := range regs {
+		if regs[i].Name == reg.Name {
+			index = i
+			break
+		}
+	}
+
+	if reg.Status == "" {
+		reg.Status = StatusUnverified
+	}
+	if reg.RegisteredAt.IsZero() {
+		if index >= 0 && !regs[index].RegisteredAt.IsZero() {
+			reg.RegisteredAt = regs[index].RegisteredAt
+		} else {
+			reg.RegisteredAt = now
+		}
+	}
+	if reg.LastHealthCheck.IsZero() && index >= 0 {
+		reg.LastHealthCheck = regs[index].LastHealthCheck
+	}
+
+	if index >= 0 {
+		regs[index] = reg
+	} else {
+		regs = append(regs, reg)
+	}
+
+	return s.save(regs)
+}
+
+// Delete removes a registration by name. Deleting a missing name is a no-op.
+func (s *FileStore) Delete(ctx context.Context, name string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if s == nil {
+		return errors.New("tool: file store is nil")
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	regs, err := s.load()
+	if err != nil {
+		return err
+	}
+
+	filtered := make([]ToolRegistration, 0, len(regs))
+	for _, reg := range regs {
+		if reg.Name != name {
+			filtered = append(filtered, reg)
+		}
+	}
+	return s.save(filtered)
+}
+
+func (s *FileStore) load() ([]ToolRegistration, error) {
+	if strings.TrimSpace(s.path) == "" {
+		return nil, errEmptyStorePath
+	}
+
+	// #nosec G304 -- path is configured by caller and constrained to local filesystem usage.
+	data, err := os.ReadFile(s.path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []ToolRegistration{}, nil
+		}
+		return nil, fmt.Errorf("tool: read registrations: %w", err)
+	}
+	if len(data) == 0 {
+		return []ToolRegistration{}, nil
+	}
+
+	var doc fileStoreDocument
+	if err := json.Unmarshal(data, &doc); err == nil && doc.Tools != nil {
+		sortRegistrations(doc.Tools)
+		return doc.Tools, nil
+	}
+
+	// Backward-compatibility: permit a plain array payload.
+	var regs []ToolRegistration
+	if err := json.Unmarshal(data, &regs); err != nil {
+		return nil, fmt.Errorf("tool: decode registrations: %w", err)
+	}
+	sortRegistrations(regs)
+	return regs, nil
+}
+
+func (s *FileStore) save(regs []ToolRegistration) error {
+	if strings.TrimSpace(s.path) == "" {
+		return errEmptyStorePath
+	}
+
+	regs = cloneRegistrations(regs)
+	sortRegistrations(regs)
+
+	doc := fileStoreDocument{
+		Version: fileStoreVersionV1,
+		Tools:   regs,
+	}
+
+	data, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("tool: encode registrations: %w", err)
+	}
+	data = append(data, '\n')
+
+	if err := os.MkdirAll(filepath.Dir(s.path), 0o750); err != nil {
+		return fmt.Errorf("tool: create store dir: %w", err)
+	}
+
+	tmp := s.path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("tool: write temp store file: %w", err)
+	}
+	if err := os.Rename(tmp, s.path); err != nil {
+		return fmt.Errorf("tool: replace store file: %w", err)
+	}
+	return nil
+}
+
+func sortRegistrations(regs []ToolRegistration) {
+	slices.SortFunc(regs, func(a, b ToolRegistration) int {
+		return strings.Compare(a.Name, b.Name)
+	})
+}
+
+func cloneRegistrations(in []ToolRegistration) []ToolRegistration {
+	out := make([]ToolRegistration, len(in))
+	for i := range in {
+		out[i] = cloneRegistration(in[i])
+	}
+	return out
+}
+
+func cloneRegistration(in ToolRegistration) ToolRegistration {
+	out := in
+	if in.Config != nil {
+		out.Config = make(map[string]string, len(in.Config))
+		for k, v := range in.Config {
+			out.Config[k] = v
+		}
+	}
+	if in.Overlay != nil {
+		overlay := *in.Overlay
+		out.Overlay = &overlay
+	}
+	return out
+}
+
+var _ Store = (*FileStore)(nil)

--- a/tool/store_file_test.go
+++ b/tool/store_file_test.go
@@ -1,0 +1,145 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFileStoreListEmptyWhenMissing(t *testing.T) {
+	store := NewFileStore(filepath.Join(t.TempDir(), "tools.json"))
+
+	regs, err := store.List(context.Background())
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(regs) != 0 {
+		t.Fatalf("len(List()) = %d, want 0", len(regs))
+	}
+}
+
+func TestFileStoreUpsertGetDeleteRoundTrip(t *testing.T) {
+	store := NewFileStore(filepath.Join(t.TempDir(), "tools.json"))
+	ctx := context.Background()
+
+	reg := ToolRegistration{
+		Name:     "s3_fetch",
+		Origin:   OriginMCP,
+		Manifest: NewManifest("s3_fetch"),
+		Status:   StatusReady,
+		Config: map[string]string{
+			"region": "us-west-2",
+		},
+		RegisteredAt:    time.Date(2026, 2, 9, 0, 0, 0, 0, time.UTC),
+		LastHealthCheck: time.Date(2026, 2, 9, 1, 0, 0, 0, time.UTC),
+		Overlay: &ToolOverlay{
+			Path: "./tools/s3.overlay.yaml",
+		},
+	}
+	reg.Manifest.Transport = NewMCPTransport(MCPTransport{
+		Mode:    MCPModeStdio,
+		Command: "npx",
+	})
+
+	if err := store.Upsert(ctx, reg); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	got, ok, err := store.Get(ctx, "s3_fetch")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("Get() ok = false, want true")
+	}
+	if got.Name != "s3_fetch" {
+		t.Fatalf("Name = %q, want s3_fetch", got.Name)
+	}
+	if got.Config["region"] != "us-west-2" {
+		t.Fatalf("Config[region] = %q, want us-west-2", got.Config["region"])
+	}
+	if got.Origin != OriginMCP {
+		t.Fatalf("Origin = %q, want %q", got.Origin, OriginMCP)
+	}
+	if got.Overlay == nil || got.Overlay.Path == "" {
+		t.Fatal("Overlay should be present")
+	}
+
+	if err := store.Delete(ctx, "s3_fetch"); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	_, ok, err = store.Get(ctx, "s3_fetch")
+	if err != nil {
+		t.Fatalf("Get() after delete error = %v", err)
+	}
+	if ok {
+		t.Fatal("Get() after delete ok = true, want false")
+	}
+}
+
+func TestFileStoreDeterministicOrderAndVersionedDocument(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "tools.json")
+	store := NewFileStore(path)
+	ctx := context.Background()
+
+	regA := ToolRegistration{
+		Name:     "alpha",
+		Origin:   OriginHTTP,
+		Manifest: NewManifest("alpha"),
+		Status:   StatusUnverified,
+	}
+	regA.Manifest.Transport = NewHTTPTransport(HTTPTransport{Endpoint: "http://localhost:9001"})
+
+	regB := ToolRegistration{
+		Name:     "beta",
+		Origin:   OriginStdio,
+		Manifest: NewManifest("beta"),
+		Status:   StatusReady,
+	}
+	regB.Manifest.Transport = NewStdioTransport(StdioTransport{Command: "./beta"})
+
+	if err := store.Upsert(ctx, regB); err != nil {
+		t.Fatalf("Upsert(beta) error = %v", err)
+	}
+	if err := store.Upsert(ctx, regA); err != nil {
+		t.Fatalf("Upsert(alpha) error = %v", err)
+	}
+
+	list, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("len(List()) = %d, want 2", len(list))
+	}
+	if list[0].Name != "alpha" || list[1].Name != "beta" {
+		t.Fatalf("List order = [%s, %s], want [alpha, beta]", list[0].Name, list[1].Name)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	var doc fileStoreDocument
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if doc.Version != fileStoreVersionV1 {
+		t.Fatalf("version = %q, want %q", doc.Version, fileStoreVersionV1)
+	}
+	if len(doc.Tools) != 2 {
+		t.Fatalf("len(doc.Tools) = %d, want 2", len(doc.Tools))
+	}
+}
+
+func TestFileStoreEmptyPathError(t *testing.T) {
+	store := NewFileStore("")
+	if err := store.Upsert(context.Background(), ToolRegistration{Name: "x", Manifest: NewManifest("x")}); err == nil {
+		t.Fatal("Upsert() error = nil, want non-nil for empty path")
+	}
+}


### PR DESCRIPTION
## Summary
Implements issue #28 (`P1-05`) by introducing a shared `ToolRegistration` model and store abstraction that works for both CLI and daemon/server paths.

## What changed
- Updated registration model in `tool/registry.go`:
  - Added `ToolOrigin` enum (`native`, `mcp`, `http`, `stdio`)
  - Added `ToolOverlay` placeholder model
  - Introduced FRD-aligned `ToolRegistration` fields (`origin`, `config`, `status`, `registered_at`, `last_health_check`, `overlay`)
  - Kept compatibility alias: `type Registration = ToolRegistration`
  - Kept shared `Store` interface as the cross-path contract
- Added CLI file-backed store implementation in `tool/store_file.go`:
  - `FileStore` implementing `Store`
  - default path helpers (`~/.petalflow/tools.json`)
  - deterministic name-sorted persistence
  - atomic file replacement writes
  - backward-compatible read path (versioned document or plain array)
- Added daemon store adapter abstraction in `tool/store_daemon.go`:
  - `DaemonRegistryBackend` interface for server persistence layer
  - `DaemonStore` adapter implementing shared `Store`

## Tests
- Added file store tests in `tool/store_file_test.go`:
  - empty missing file behavior
  - upsert/get/delete round-trip
  - deterministic ordering and versioned file format
  - empty path error handling
- Added daemon store tests in `tool/store_daemon_test.go`:
  - nil backend guards
  - CRUD forwarding behavior

## Validation
- `gofmt -w tool/registry.go tool/store_file.go tool/store_file_test.go tool/store_daemon.go tool/store_daemon_test.go`
- `GOCACHE=/tmp/petalflow-gocache go test ./tool/...`
- `GOCACHE=/tmp/petalflow-gocache gosec -exclude-dir=examples -exclude-dir=irisadapter ./tool/...`

Closes #28
