### PR TITLE
Phase 1 foundation: adapters, built-ins, tools CLI, validation, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,14 @@ petalflow run workflow.yaml --input '{"topic": "AI agents"}'
 
 # Dry run (validate + compile only, no execution)
 petalflow run workflow.yaml --dry-run
+
+# Register and inspect tools
+petalflow tools register echo_http --type http --manifest ./tools/echo_http.tool.json
+petalflow tools list
+petalflow tools inspect echo_http
 ```
+
+Tooling quickstart and troubleshooting: [`docs/tools-cli.md`](./docs/tools-cli.md)
 
 ### Agent/Task Schema
 

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -22,6 +22,7 @@ func newTestRoot() *cobra.Command {
 	root.AddCommand(NewRunCmd())
 	root.AddCommand(NewCompileCmd())
 	root.AddCommand(NewValidateCmd())
+	root.AddCommand(NewToolsCmd())
 	return root
 }
 

--- a/cli/tools.go
+++ b/cli/tools.go
@@ -1,0 +1,730 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+
+	"github.com/petal-labs/petalflow/tool"
+)
+
+// NewToolsCmd creates the "tools" command group.
+func NewToolsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "tools",
+		Short: "Manage tool registrations",
+	}
+	cmd.PersistentFlags().String("store-path", "", "Path to tool registry store file (default: ~/.petalflow/tools.json)")
+
+	cmd.AddCommand(newToolsRegisterCmd())
+	cmd.AddCommand(newToolsListCmd())
+	cmd.AddCommand(newToolsInspectCmd())
+	cmd.AddCommand(newToolsUnregisterCmd())
+	cmd.AddCommand(newToolsConfigCmd())
+	cmd.AddCommand(newToolsTestCmd())
+
+	return cmd
+}
+
+func newToolsRegisterCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "register <name>",
+		Short: "Register a tool in the local registry",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runToolsRegister,
+	}
+	cmd.Flags().String("type", "", "Tool origin: native | http | stdio | mcp")
+	cmd.Flags().String("manifest", "", "Path to manifest JSON")
+	cmd.Flags().String("endpoint", "", "Transport endpoint override")
+	cmd.Flags().String("command", "", "Transport command override")
+	cmd.Flags().StringArray("arg", nil, "Transport argument override (repeatable)")
+	cmd.Flags().StringArray("env", nil, "Transport environment override KEY=VALUE (repeatable)")
+	return cmd
+}
+
+func runToolsRegister(cmd *cobra.Command, args []string) error {
+	name := strings.TrimSpace(args[0])
+	store, err := resolveToolStore(cmd)
+	if err != nil {
+		return err
+	}
+
+	manifestPath, _ := cmd.Flags().GetString("manifest")
+	originValue, _ := cmd.Flags().GetString("type")
+	origin, err := parseToolOrigin(originValue)
+	if err != nil {
+		return exitError(exitValidation, "%s", err.Error())
+	}
+
+	var registration tool.ToolRegistration
+	if manifestPath == "" && origin == tool.OriginNative {
+		builtin, ok := tool.BuiltinRegistration(name)
+		if !ok {
+			return exitError(exitValidation, "native tool %q requires --manifest (built-in not found)", name)
+		}
+		registration = builtin
+	} else {
+		if manifestPath == "" {
+			return exitError(exitValidation, "--manifest is required for non-native registrations")
+		}
+		manifest, err := loadManifestFile(manifestPath)
+		if err != nil {
+			return exitError(exitValidation, "loading manifest: %v", err)
+		}
+		if strings.TrimSpace(manifest.Tool.Name) == "" {
+			manifest.Tool.Name = name
+		}
+		if manifest.Tool.Name != name {
+			return exitError(exitValidation, "manifest tool.name %q does not match registration name %q", manifest.Tool.Name, name)
+		}
+
+		if origin == "" {
+			origin = originFromTransport(manifest.Transport.Type)
+		}
+		if origin == "" {
+			return exitError(exitValidation, "unable to infer tool origin from manifest transport %q", manifest.Transport.Type)
+		}
+
+		registration = tool.ToolRegistration{
+			Name:     name,
+			Manifest: manifest,
+			Origin:   origin,
+			Status:   tool.StatusReady,
+			Enabled:  true,
+			Config:   map[string]string{},
+		}
+	}
+
+	if err := applyTransportOverrides(cmd, &registration.Manifest); err != nil {
+		return exitError(exitValidation, "%s", err.Error())
+	}
+	if registration.Origin == "" {
+		registration.Origin = originFromTransport(registration.Manifest.Transport.Type)
+	}
+	if registration.Origin == "" {
+		return exitError(exitValidation, "tool origin must be set via --type or manifest transport")
+	}
+
+	if registration.Status == "" {
+		registration.Status = tool.StatusReady
+	}
+	if registration.Config == nil {
+		registration.Config = map[string]string{}
+	}
+
+	if err := tool.ValidateNewRegistration(cmd.Context(), registration, tool.RegistrationValidationOptions{
+		Store: store,
+	}); err != nil {
+		return formatRegistrationValidationError(err)
+	}
+
+	if err := store.Upsert(cmd.Context(), registration); err != nil {
+		return exitError(exitRuntime, "saving registration: %v", err)
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Registered tool: %s (%s)\n", registration.Name, registration.Origin)
+	return nil
+}
+
+func newToolsListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List registered and built-in tools",
+		RunE:  runToolsList,
+	}
+}
+
+func runToolsList(cmd *cobra.Command, args []string) error {
+	store, err := resolveToolStore(cmd)
+	if err != nil {
+		return err
+	}
+
+	stored, err := store.List(cmd.Context())
+	if err != nil {
+		return exitError(exitRuntime, "listing tools: %v", err)
+	}
+	combined := mergeTools(tool.BuiltinRegistrations(), stored)
+
+	writer := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 2, 2, ' ', 0)
+	fmt.Fprintln(writer, "NAME\tTYPE\tTRANSPORT\tACTIONS\tSTATUS\tVERSION")
+	for _, reg := range combined {
+		actions := strings.Join(reg.ActionNames(), ",")
+		if actions == "" {
+			actions = "-"
+		}
+		version := strings.TrimSpace(reg.Manifest.Tool.Version)
+		if version == "" {
+			version = "-"
+		}
+		fmt.Fprintf(
+			writer,
+			"%s\t%s\t%s\t%s\t%s\t%s\n",
+			reg.Name,
+			displayOrigin(reg),
+			displayTransport(reg.Manifest.Transport.Type),
+			actions,
+			reg.Status,
+			version,
+		)
+	}
+	return writer.Flush()
+}
+
+func newToolsInspectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "inspect <name>",
+		Short: "Inspect a tool registration manifest",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runToolsInspect,
+	}
+	cmd.Flags().Bool("actions", false, "Show action schemas only")
+	return cmd
+}
+
+func runToolsInspect(cmd *cobra.Command, args []string) error {
+	store, err := resolveToolStore(cmd)
+	if err != nil {
+		return err
+	}
+
+	name := args[0]
+	reg, found, err := resolveRegistration(cmd.Context(), store, name)
+	if err != nil {
+		return exitError(exitRuntime, "loading tool: %v", err)
+	}
+	if !found {
+		return exitError(exitValidation, "tool %q is not registered", name)
+	}
+
+	actionsOnly, _ := cmd.Flags().GetBool("actions")
+	out := cmd.OutOrStdout()
+	if actionsOnly {
+		data, err := json.MarshalIndent(reg.Manifest.Actions, "", "  ")
+		if err != nil {
+			return exitError(exitRuntime, "encoding actions: %v", err)
+		}
+		_, _ = out.Write(append(data, '\n'))
+		return nil
+	}
+
+	view := reg
+	view.Config = maskSensitiveConfig(reg.Manifest.Config, reg.Config)
+	data, err := json.MarshalIndent(view, "", "  ")
+	if err != nil {
+		return exitError(exitRuntime, "encoding registration: %v", err)
+	}
+	_, _ = out.Write(append(data, '\n'))
+	return nil
+}
+
+func newToolsUnregisterCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "unregister <name>",
+		Short: "Unregister a tool from the local registry",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runToolsUnregister,
+	}
+}
+
+func runToolsUnregister(cmd *cobra.Command, args []string) error {
+	store, err := resolveToolStore(cmd)
+	if err != nil {
+		return err
+	}
+	name := args[0]
+	if err := store.Delete(cmd.Context(), name); err != nil {
+		return exitError(exitRuntime, "unregistering %q: %v", name, err)
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Unregistered tool: %s\n", name)
+	return nil
+}
+
+func newToolsConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config <name>",
+		Short: "Set or show tool config values",
+		Args:  cobra.ExactArgs(1),
+		RunE:  runToolsConfig,
+	}
+	cmd.Flags().StringArray("set", nil, "Set config value KEY=VALUE (repeatable)")
+	cmd.Flags().StringArray("set-secret", nil, "Set sensitive config KEY=VALUE (repeatable)")
+	cmd.Flags().Bool("show", false, "Show effective config values")
+	return cmd
+}
+
+func runToolsConfig(cmd *cobra.Command, args []string) error {
+	store, err := resolveToolStore(cmd)
+	if err != nil {
+		return err
+	}
+	name := args[0]
+	reg, found, err := resolveRegistration(cmd.Context(), store, name)
+	if err != nil {
+		return exitError(exitRuntime, "loading tool: %v", err)
+	}
+	if !found {
+		return exitError(exitValidation, "tool %q is not registered", name)
+	}
+
+	if reg.Config == nil {
+		reg.Config = make(map[string]string)
+	}
+	if reg.Manifest.Config == nil {
+		reg.Manifest.Config = make(map[string]tool.FieldSpec)
+	}
+
+	setValues, _ := cmd.Flags().GetStringArray("set")
+	secretValues, _ := cmd.Flags().GetStringArray("set-secret")
+	show, _ := cmd.Flags().GetBool("show")
+
+	updated := 0
+	for _, value := range setValues {
+		key, parsed, err := parseKeyValue(value, true)
+		if err != nil {
+			return exitError(exitInputParse, "invalid --set value %q: %v", value, err)
+		}
+		spec := reg.Manifest.Config[key]
+		if spec.Sensitive {
+			return exitError(exitInputParse, "config %q is sensitive; use --set-secret", key)
+		}
+		reg.Config[key] = parsed
+		updated++
+	}
+
+	for _, value := range secretValues {
+		key, parsed, err := parseKeyValue(value, false)
+		if err != nil {
+			return exitError(exitInputParse, "invalid --set-secret value %q: %v", value, err)
+		}
+		if parsed == "" {
+			return exitError(exitInputParse, "secret value for %q is empty", key)
+		}
+
+		spec := reg.Manifest.Config[key]
+		if spec.Type == "" {
+			spec.Type = tool.TypeString
+		}
+		spec.Sensitive = true
+		reg.Manifest.Config[key] = spec
+
+		reg.Config[key] = parsed
+		updated++
+	}
+
+	if updated > 0 {
+		if err := validateConfigOnly(reg); err != nil {
+			return formatRegistrationValidationError(err)
+		}
+		if err := store.Upsert(cmd.Context(), reg); err != nil {
+			return exitError(exitRuntime, "saving config: %v", err)
+		}
+	}
+
+	if show || updated == 0 {
+		printToolConfig(cmd, reg)
+		return nil
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Updated %d config value(s) for %s\n", updated, reg.Name)
+	return nil
+}
+
+func newToolsTestCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "test <name> <action>",
+		Short: "Invoke a tool action with test inputs",
+		Args:  cobra.ExactArgs(2),
+		RunE:  runToolsTest,
+	}
+	cmd.Flags().StringArray("input", nil, "Input KEY=VALUE pair (repeatable)")
+	cmd.Flags().String("input-json", "", "Input object as JSON")
+	return cmd
+}
+
+func runToolsTest(cmd *cobra.Command, args []string) error {
+	store, err := resolveToolStore(cmd)
+	if err != nil {
+		return err
+	}
+	name := args[0]
+	action := args[1]
+
+	reg, found, err := resolveRegistration(cmd.Context(), store, name)
+	if err != nil {
+		return exitError(exitRuntime, "loading tool: %v", err)
+	}
+	if !found {
+		return exitError(exitValidation, "tool %q is not registered", name)
+	}
+
+	inputs, err := parseToolTestInputs(cmd)
+	if err != nil {
+		return exitError(exitInputParse, "parsing inputs: %v", err)
+	}
+
+	factory := tool.DefaultAdapterFactory{NativeLookup: tool.LookupBuiltinNativeTool}
+	adapter, err := factory.New(reg)
+	if err != nil {
+		return exitError(exitRuntime, "creating adapter: %v", err)
+	}
+	defer adapter.Close(cmd.Context())
+
+	resp, err := adapter.Invoke(cmd.Context(), tool.InvokeRequest{
+		ToolName: name,
+		Action:   action,
+		Inputs:   inputs,
+		Config:   configAsAny(reg.Config),
+	})
+	if err != nil {
+		return exitError(exitRuntime, "tool test failed: %v", err)
+	}
+
+	result := map[string]any{
+		"success":     true,
+		"tool":        name,
+		"action":      action,
+		"duration_ms": resp.DurationMS,
+		"outputs":     resp.Outputs,
+	}
+	if len(resp.Metadata) > 0 {
+		result["metadata"] = resp.Metadata
+	}
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return exitError(exitRuntime, "encoding test result: %v", err)
+	}
+
+	_, _ = cmd.OutOrStdout().Write(append(data, '\n'))
+	return nil
+}
+
+func resolveToolStore(cmd *cobra.Command) (tool.Store, error) {
+	storePath, _ := cmd.Flags().GetString("store-path")
+	if strings.TrimSpace(storePath) == "" {
+		storePath = os.Getenv("PETALFLOW_TOOLS_STORE_PATH")
+	}
+	if strings.TrimSpace(storePath) == "" {
+		return tool.NewDefaultFileStore()
+	}
+	clean := filepath.Clean(storePath)
+	return tool.NewFileStore(clean), nil
+}
+
+func resolveRegistration(ctx context.Context, store tool.Store, name string) (tool.ToolRegistration, bool, error) {
+	reg, found, err := store.Get(ctx, name)
+	if err != nil {
+		return tool.ToolRegistration{}, false, err
+	}
+	if found {
+		return reg, true, nil
+	}
+	builtin, ok := tool.BuiltinRegistration(name)
+	return builtin, ok, nil
+}
+
+func loadManifestFile(path string) (tool.Manifest, error) {
+	data, err := os.ReadFile(path) // #nosec G304 -- CLI path argument.
+	if err != nil {
+		return tool.Manifest{}, err
+	}
+	var manifest tool.Manifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return tool.Manifest{}, err
+	}
+	return manifest, nil
+}
+
+func parseToolOrigin(value string) (tool.ToolOrigin, error) {
+	switch strings.TrimSpace(value) {
+	case "":
+		return "", nil
+	case string(tool.OriginNative):
+		return tool.OriginNative, nil
+	case string(tool.OriginHTTP):
+		return tool.OriginHTTP, nil
+	case string(tool.OriginStdio):
+		return tool.OriginStdio, nil
+	case string(tool.OriginMCP):
+		return tool.OriginMCP, nil
+	default:
+		return "", fmt.Errorf("unsupported --type %q (use native, http, stdio, mcp)", value)
+	}
+}
+
+func originFromTransport(transport tool.TransportType) tool.ToolOrigin {
+	switch transport {
+	case tool.TransportTypeNative:
+		return tool.OriginNative
+	case tool.TransportTypeHTTP:
+		return tool.OriginHTTP
+	case tool.TransportTypeStdio:
+		return tool.OriginStdio
+	case tool.TransportTypeMCP:
+		return tool.OriginMCP
+	default:
+		return ""
+	}
+}
+
+func applyTransportOverrides(cmd *cobra.Command, manifest *tool.Manifest) error {
+	endpoint, _ := cmd.Flags().GetString("endpoint")
+	command, _ := cmd.Flags().GetString("command")
+	args, _ := cmd.Flags().GetStringArray("arg")
+	envPairs, _ := cmd.Flags().GetStringArray("env")
+
+	if endpoint != "" {
+		manifest.Transport.Endpoint = endpoint
+	}
+	if command != "" {
+		manifest.Transport.Command = command
+	}
+	if len(args) > 0 {
+		manifest.Transport.Args = slices.Clone(args)
+	}
+	if len(envPairs) > 0 {
+		env := make(map[string]string, len(envPairs))
+		for _, pair := range envPairs {
+			key, value, err := parseKeyValue(pair, true)
+			if err != nil {
+				return fmt.Errorf("invalid --env %q: %w", pair, err)
+			}
+			env[key] = value
+		}
+		manifest.Transport.Env = env
+	}
+
+	if manifest.Transport.Type == "" {
+		switch {
+		case endpoint != "":
+			manifest.Transport.Type = tool.TransportTypeHTTP
+		case command != "":
+			manifest.Transport.Type = tool.TransportTypeStdio
+		}
+	}
+
+	return nil
+}
+
+func displayOrigin(reg tool.ToolRegistration) tool.ToolOrigin {
+	if reg.Origin != "" {
+		return reg.Origin
+	}
+	return originFromTransport(reg.Manifest.Transport.Type)
+}
+
+func displayTransport(transport tool.TransportType) string {
+	switch transport {
+	case tool.TransportTypeNative:
+		return "in-process"
+	case "":
+		return "-"
+	default:
+		return string(transport)
+	}
+}
+
+func mergeTools(builtins []tool.ToolRegistration, stored []tool.ToolRegistration) []tool.ToolRegistration {
+	byName := make(map[string]tool.ToolRegistration, len(builtins)+len(stored))
+	for _, reg := range builtins {
+		byName[reg.Name] = reg
+	}
+	for _, reg := range stored {
+		byName[reg.Name] = reg
+	}
+
+	names := make([]string, 0, len(byName))
+	for name := range byName {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	out := make([]tool.ToolRegistration, 0, len(names))
+	for _, name := range names {
+		out = append(out, byName[name])
+	}
+	return out
+}
+
+func maskSensitiveConfig(specs map[string]tool.FieldSpec, values map[string]string) map[string]string {
+	masked := make(map[string]string, len(values))
+	for key, value := range values {
+		spec, ok := specs[key]
+		if ok && spec.Sensitive && strings.TrimSpace(value) != "" {
+			masked[key] = "**********"
+			continue
+		}
+		masked[key] = value
+	}
+	return masked
+}
+
+func printToolConfig(cmd *cobra.Command, reg tool.ToolRegistration) {
+	fmt.Fprintf(cmd.OutOrStdout(), "Tool: %s\n", reg.Name)
+	fmt.Fprintln(cmd.OutOrStdout(), "Config:")
+
+	keys := map[string]struct{}{}
+	for key := range reg.Manifest.Config {
+		keys[key] = struct{}{}
+	}
+	for key := range reg.Config {
+		keys[key] = struct{}{}
+	}
+
+	sortedKeys := make([]string, 0, len(keys))
+	for key := range keys {
+		sortedKeys = append(sortedKeys, key)
+	}
+	slices.Sort(sortedKeys)
+
+	for _, key := range sortedKeys {
+		spec := reg.Manifest.Config[key]
+		value := reg.Config[key]
+		display := value
+		suffix := ""
+		if strings.TrimSpace(value) == "" {
+			display = "(unset)"
+		}
+		if spec.Sensitive && strings.TrimSpace(value) != "" {
+			display = "**********"
+			suffix = " (sensitive)"
+		} else if spec.Sensitive {
+			suffix = " (sensitive)"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "  %s: %s%s\n", key, display, suffix)
+	}
+}
+
+func parseKeyValue(value string, requireValue bool) (string, string, error) {
+	parts := strings.SplitN(value, "=", 2)
+	key := strings.TrimSpace(parts[0])
+	if key == "" {
+		return "", "", errors.New("key is required")
+	}
+	if len(parts) == 1 {
+		if requireValue {
+			return "", "", errors.New("value is required")
+		}
+		return key, "", nil
+	}
+	return key, parts[1], nil
+}
+
+func parseToolTestInputs(cmd *cobra.Command) (map[string]any, error) {
+	inputs := map[string]any{}
+	rawPairs, _ := cmd.Flags().GetStringArray("input")
+	for _, pair := range rawPairs {
+		key, value, err := parseKeyValue(pair, true)
+		if err != nil {
+			return nil, err
+		}
+		inputs[key] = parsePrimitiveValue(value)
+	}
+
+	inputJSON, _ := cmd.Flags().GetString("input-json")
+	if strings.TrimSpace(inputJSON) == "" {
+		return inputs, nil
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(inputJSON), &obj); err != nil {
+		return nil, err
+	}
+	for key, value := range obj {
+		inputs[key] = value
+	}
+	return inputs, nil
+}
+
+func parsePrimitiveValue(value string) any {
+	if value == "true" {
+		return true
+	}
+	if value == "false" {
+		return false
+	}
+	if i, err := strconv.ParseInt(value, 10, 64); err == nil {
+		return i
+	}
+	if f, err := strconv.ParseFloat(value, 64); err == nil {
+		return f
+	}
+
+	trimmed := strings.TrimSpace(value)
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") || strings.HasPrefix(trimmed, "\"") {
+		var parsed any
+		if err := json.Unmarshal([]byte(trimmed), &parsed); err == nil {
+			return parsed
+		}
+	}
+	return value
+}
+
+func configAsAny(values map[string]string) map[string]any {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
+	return out
+}
+
+func validateConfigOnly(reg tool.ToolRegistration) error {
+	var pipeline tool.Pipeline
+	pipeline.AddManifestValidator(tool.SchemaManifestValidator{})
+	pipeline.AddManifestValidator(tool.V1TypeSystemValidator{})
+	pipeline.AddRegistrationValidator(tool.ConfigCompletenessValidator{})
+	pipeline.AddRegistrationValidator(tool.SensitiveFieldValidator{})
+
+	manifestResult := pipeline.ValidateManifest(reg.Manifest)
+	registrationResult := pipeline.ValidateRegistration(reg)
+	diags := append(manifestResult.Diagnostics, registrationResult.Diagnostics...)
+	if !hasToolErrors(diags) {
+		return nil
+	}
+
+	return &tool.RegistrationValidationError{
+		Code:    tool.RegistrationValidationFailedCode,
+		Message: "Tool registration failed validation",
+		Details: diags,
+	}
+}
+
+func hasToolErrors(diags []tool.Diagnostic) bool {
+	for _, diag := range diags {
+		if diag.Severity == tool.SeverityError {
+			return true
+		}
+	}
+	return false
+}
+
+func formatRegistrationValidationError(err error) error {
+	var validationErr *tool.RegistrationValidationError
+	if !errors.As(err, &validationErr) {
+		return exitError(exitValidation, "%s", err.Error())
+	}
+
+	builder := strings.Builder{}
+	builder.WriteString(validationErr.Message)
+	for _, detail := range validationErr.Details {
+		builder.WriteString("\n - ")
+		builder.WriteString(detail.Field)
+		builder.WriteString(" [")
+		builder.WriteString(detail.Code)
+		builder.WriteString("] ")
+		builder.WriteString(detail.Message)
+	}
+	return exitError(exitValidation, "%s", builder.String())
+}

--- a/cli/tools_test.go
+++ b/cli/tools_test.go
@@ -1,0 +1,183 @@
+package cli
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestToolsRegisterListInspectUnregister(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "tools.json")
+	t.Setenv("PETALFLOW_TOOLS_STORE_PATH", storePath)
+
+	manifest := map[string]any{
+		"manifest_version": "1.0",
+		"tool": map[string]any{
+			"name":        "echo_stdio",
+			"version":     "0.1.0",
+			"description": "Echo test tool",
+		},
+		"transport": map[string]any{
+			"type":    "stdio",
+			"command": "cat",
+		},
+		"actions": map[string]any{
+			"echo": map[string]any{
+				"inputs": map[string]any{
+					"value": map[string]any{"type": "string"},
+				},
+				"outputs": map[string]any{
+					"value": map[string]any{"type": "string"},
+				},
+			},
+		},
+	}
+	manifestPath := writeManifestFile(t, manifest)
+
+	root := newTestRoot()
+	stdout, _, err := executeCommand(root, "tools", "register", "echo_stdio", "--type", "stdio", "--manifest", manifestPath)
+	if err != nil {
+		t.Fatalf("register error = %v", err)
+	}
+	if !strings.Contains(stdout, "Registered tool: echo_stdio") {
+		t.Fatalf("register output = %q, want success message", stdout)
+	}
+
+	root = newTestRoot()
+	stdout, _, err = executeCommand(root, "tools", "list")
+	if err != nil {
+		t.Fatalf("list error = %v", err)
+	}
+	if !strings.Contains(stdout, "echo_stdio") {
+		t.Fatalf("list output missing tool: %q", stdout)
+	}
+	if !strings.Contains(stdout, "NAME") {
+		t.Fatalf("list output missing header: %q", stdout)
+	}
+
+	root = newTestRoot()
+	stdout, _, err = executeCommand(root, "tools", "inspect", "echo_stdio")
+	if err != nil {
+		t.Fatalf("inspect error = %v", err)
+	}
+	if !strings.Contains(stdout, `"name": "echo_stdio"`) {
+		t.Fatalf("inspect output missing name: %q", stdout)
+	}
+
+	root = newTestRoot()
+	stdout, _, err = executeCommand(root, "tools", "unregister", "echo_stdio")
+	if err != nil {
+		t.Fatalf("unregister error = %v", err)
+	}
+	if !strings.Contains(stdout, "Unregistered tool: echo_stdio") {
+		t.Fatalf("unregister output = %q, want success message", stdout)
+	}
+}
+
+func TestToolsConfigMasksSensitiveValues(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "tools.json")
+	t.Setenv("PETALFLOW_TOOLS_STORE_PATH", storePath)
+
+	root := newTestRoot()
+	stdout, _, err := executeCommand(
+		root,
+		"tools",
+		"config",
+		"http_fetch",
+		"--set-secret", "authorization=Bearer super-secret-token",
+		"--show",
+	)
+	if err != nil {
+		t.Fatalf("config error = %v", err)
+	}
+	if strings.Contains(stdout, "super-secret-token") {
+		t.Fatalf("config output leaked secret: %q", stdout)
+	}
+	if !strings.Contains(stdout, "**********") {
+		t.Fatalf("config output missing masked value: %q", stdout)
+	}
+	if !strings.Contains(stdout, "(sensitive)") {
+		t.Fatalf("config output missing sensitive marker: %q", stdout)
+	}
+
+	root = newTestRoot()
+	stdout, _, err = executeCommand(root, "tools", "inspect", "http_fetch")
+	if err != nil {
+		t.Fatalf("inspect error = %v", err)
+	}
+	if strings.Contains(stdout, "super-secret-token") {
+		t.Fatalf("inspect output leaked secret: %q", stdout)
+	}
+}
+
+func TestToolsTestInvokesNativeBuiltin(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "tools.json")
+	t.Setenv("PETALFLOW_TOOLS_STORE_PATH", storePath)
+
+	root := newTestRoot()
+	stdout, _, err := executeCommand(
+		root,
+		"tools",
+		"test",
+		"template_render",
+		"render",
+		"--input", "template=Hello, {{.name}}!",
+		"--input", "name=Ada",
+	)
+	if err != nil {
+		t.Fatalf("tools test error = %v", err)
+	}
+	if !strings.Contains(stdout, `"success": true`) {
+		t.Fatalf("test output missing success: %q", stdout)
+	}
+	if !strings.Contains(stdout, `"rendered": "Hello, Ada!"`) {
+		t.Fatalf("test output missing rendered value: %q", stdout)
+	}
+}
+
+func TestToolsRegisterDuplicateNameShowsValidationCode(t *testing.T) {
+	storePath := filepath.Join(t.TempDir(), "tools.json")
+	t.Setenv("PETALFLOW_TOOLS_STORE_PATH", storePath)
+
+	manifest := map[string]any{
+		"manifest_version": "1.0",
+		"tool": map[string]any{
+			"name": "dup_stdio",
+		},
+		"transport": map[string]any{
+			"type":    "stdio",
+			"command": "cat",
+		},
+		"actions": map[string]any{
+			"echo": map[string]any{
+				"inputs": map[string]any{},
+			},
+		},
+	}
+	manifestPath := writeManifestFile(t, manifest)
+
+	root := newTestRoot()
+	_, _, err := executeCommand(root, "tools", "register", "dup_stdio", "--type", "stdio", "--manifest", manifestPath)
+	if err != nil {
+		t.Fatalf("first register error = %v", err)
+	}
+
+	root = newTestRoot()
+	_, _, err = executeCommand(root, "tools", "register", "dup_stdio", "--type", "stdio", "--manifest", manifestPath)
+	if err == nil {
+		t.Fatal("second register error = nil, want duplicate name validation error")
+	}
+	if !strings.Contains(err.Error(), "NAME_NOT_UNIQUE") {
+		t.Fatalf("duplicate register error = %q, want NAME_NOT_UNIQUE", err.Error())
+	}
+}
+
+func writeManifestFile(t *testing.T, manifest map[string]any) string {
+	t.Helper()
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	return writeTestFile(t, "tool-manifest.json", string(data))
+}

--- a/cmd/petalflow/main.go
+++ b/cmd/petalflow/main.go
@@ -43,4 +43,5 @@ func init() {
 	rootCmd.AddCommand(cli.NewCompileCmd())
 	rootCmd.AddCommand(cli.NewValidateCmd())
 	rootCmd.AddCommand(cli.NewServeCmd())
+	rootCmd.AddCommand(cli.NewToolsCmd())
 }

--- a/docs/tools-cli.md
+++ b/docs/tools-cli.md
@@ -1,0 +1,117 @@
+# Tool Manifest and CLI Quickstart
+
+This guide covers the Phase 1 tool contract workflow:
+
+- Register tools from manifest JSON.
+- List and inspect built-in + registered tools.
+- Configure required and sensitive settings.
+- Invoke tool actions from the CLI for fast validation.
+
+## 1. Manifest Shape (v1.0)
+
+Create a manifest file (for example `tools/echo_http.tool.json`):
+
+```json
+{
+  "manifest_version": "1.0",
+  "tool": {
+    "name": "echo_http",
+    "version": "0.1.0",
+    "description": "Echoes request payloads"
+  },
+  "transport": {
+    "type": "http",
+    "endpoint": "http://localhost:9801/echo"
+  },
+  "actions": {
+    "echo": {
+      "inputs": {
+        "value": { "type": "string", "required": true }
+      },
+      "outputs": {
+        "value": { "type": "string" }
+      }
+    }
+  },
+  "config": {
+    "api_key": { "type": "string", "required": true, "sensitive": true }
+  }
+}
+```
+
+## 2. Register and Inspect
+
+```bash
+# Register from manifest
+petalflow tools register echo_http \
+  --type http \
+  --manifest ./tools/echo_http.tool.json
+
+# List built-ins + registered tools
+petalflow tools list
+
+# Inspect full registration (manifest + status + masked config)
+petalflow tools inspect echo_http
+
+# Inspect action schemas only
+petalflow tools inspect echo_http --actions
+```
+
+## 3. Configure Values (Sensitive Masking)
+
+```bash
+# Set non-sensitive values
+petalflow tools config echo_http --set region=us-west-2
+
+# Set sensitive values
+petalflow tools config echo_http --set-secret api_key="sk-example"
+
+# Show effective config (sensitive values are masked)
+petalflow tools config echo_http --show
+```
+
+Expected masking behavior:
+
+```text
+Tool: echo_http
+Config:
+  api_key: ********** (sensitive)
+  region: us-west-2
+```
+
+## 4. Invoke Actions with `tools test`
+
+```bash
+petalflow tools test echo_http echo --input value=hello
+
+# JSON input form
+petalflow tools test echo_http echo \
+  --input-json '{"value":"hello"}'
+```
+
+Built-in native tools are available immediately:
+
+```bash
+petalflow tools test template_render render \
+  --input template='Hello, {{.name}}!' \
+  --input name=Ada
+```
+
+## 5. Unregister
+
+```bash
+petalflow tools unregister echo_http
+```
+
+## Troubleshooting
+
+- `REGISTRATION_VALIDATION_FAILED` with `NAME_NOT_UNIQUE`:
+  Existing registration already uses that name. Run `petalflow tools list` and choose a new name or `unregister` first.
+- `REGISTRATION_VALIDATION_FAILED` with `UNREACHABLE` on `transport.endpoint`:
+  PetalFlow could not reach the HTTP endpoint during registration. Verify service availability and URL.
+- `REGISTRATION_VALIDATION_FAILED` with `REQUIRED_FIELD` on `config.<field>`:
+  A required config value is missing. Set it via `petalflow tools config <name> --set ...` or `--set-secret ...`.
+- `tool test failed` for native tools:
+  Verify action name using `petalflow tools inspect <name> --actions`.
+- Sensitive value appears in output:
+  This is a bug. Sensitive keys declared as `sensitive: true` must always render as masked values.

--- a/tool/adapter_factory_default.go
+++ b/tool/adapter_factory_default.go
@@ -1,0 +1,57 @@
+package tool
+
+import (
+	"fmt"
+)
+
+// NativeLookup resolves a native tool implementation by registration name.
+type NativeLookup func(name string) (NativeTool, bool)
+
+// DefaultAdapterFactory resolves adapters using registration origin/transport.
+type DefaultAdapterFactory struct {
+	NativeLookup NativeLookup
+}
+
+// New builds a transport adapter for a tool registration.
+func (f DefaultAdapterFactory) New(reg Registration) (Adapter, error) {
+	switch reg.Origin {
+	case OriginNative:
+		if f.NativeLookup == nil {
+			return nil, fmt.Errorf("tool: native lookup is not configured for %q", reg.Name)
+		}
+		nativeTool, ok := f.NativeLookup(reg.Name)
+		if !ok {
+			return nil, fmt.Errorf("tool: native tool %q is not registered", reg.Name)
+		}
+		return NewNativeAdapter(nativeTool), nil
+	case OriginHTTP:
+		return NewHTTPAdapter(reg), nil
+	case OriginStdio:
+		return NewStdioAdapter(reg), nil
+	case OriginMCP:
+		return nil, fmt.Errorf("tool: mcp adapter is not implemented yet")
+	}
+
+	// Fallback to transport type when origin was not persisted.
+	switch reg.Manifest.Transport.Type {
+	case TransportTypeNative:
+		if f.NativeLookup == nil {
+			return nil, fmt.Errorf("tool: native lookup is not configured for %q", reg.Name)
+		}
+		nativeTool, ok := f.NativeLookup(reg.Name)
+		if !ok {
+			return nil, fmt.Errorf("tool: native tool %q is not registered", reg.Name)
+		}
+		return NewNativeAdapter(nativeTool), nil
+	case TransportTypeHTTP:
+		return NewHTTPAdapter(reg), nil
+	case TransportTypeStdio:
+		return NewStdioAdapter(reg), nil
+	case TransportTypeMCP:
+		return nil, fmt.Errorf("tool: mcp adapter is not implemented yet")
+	default:
+		return nil, fmt.Errorf("tool: unsupported transport %q for %q", reg.Manifest.Transport.Type, reg.Name)
+	}
+}
+
+var _ AdapterFactory = (*DefaultAdapterFactory)(nil)

--- a/tool/adapter_factory_default_test.go
+++ b/tool/adapter_factory_default_test.go
@@ -1,0 +1,115 @@
+package tool
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDefaultAdapterFactoryNative(t *testing.T) {
+	reg, ok := BuiltinRegistration("template_render")
+	if !ok {
+		t.Fatal("BuiltinRegistration(template_render) = false")
+	}
+
+	factory := DefaultAdapterFactory{NativeLookup: LookupBuiltinNativeTool}
+	adapter, err := factory.New(reg)
+	if err != nil {
+		t.Fatalf("factory.New() error = %v", err)
+	}
+
+	resp, err := invokeViaAdapter(context.Background(), adapter, InvokeRequest{
+		Action: "render",
+		Inputs: map[string]any{
+			"template": "Hi {{.name}}",
+			"name":     "Ada",
+		},
+	})
+	if err != nil {
+		t.Fatalf("invokeViaAdapter() error = %v", err)
+	}
+	if got := resp.Outputs["rendered"]; got != "Hi Ada" {
+		t.Fatalf("outputs[rendered] = %v, want %q", got, "Hi Ada")
+	}
+}
+
+func TestDefaultAdapterFactoryHTTP(t *testing.T) {
+	reg := ToolRegistration{
+		Name:     "http_tool",
+		Origin:   OriginHTTP,
+		Manifest: NewManifest("http_tool"),
+	}
+	reg.Manifest.Transport = NewHTTPTransport(HTTPTransport{Endpoint: "http://unit-test.local/check"})
+	reg.Manifest.Actions["check"] = ActionSpec{
+		Inputs:  map[string]FieldSpec{},
+		Outputs: map[string]FieldSpec{},
+	}
+
+	factory := DefaultAdapterFactory{NativeLookup: LookupBuiltinNativeTool}
+	adapter, err := factory.New(reg)
+	if err != nil {
+		t.Fatalf("factory.New() error = %v", err)
+	}
+	httpAdapter, ok := adapter.(*HTTPAdapter)
+	if !ok {
+		t.Fatalf("adapter type = %T, want *HTTPAdapter", adapter)
+	}
+	httpAdapter.client = &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"outputs":{"ok":true}}`)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	resp, err := invokeViaAdapter(context.Background(), adapter, InvokeRequest{Action: "check"})
+	if err != nil {
+		t.Fatalf("invokeViaAdapter() error = %v", err)
+	}
+	if got := resp.Outputs["ok"]; got != true {
+		t.Fatalf("outputs[ok] = %v, want true", got)
+	}
+}
+
+func TestDefaultAdapterFactoryStdio(t *testing.T) {
+	reg := ToolRegistration{
+		Name:     "stdio_tool",
+		Origin:   OriginStdio,
+		Manifest: NewManifest("stdio_tool"),
+	}
+	reg.Manifest.Transport = NewStdioTransport(StdioTransport{
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestStdioAdapterHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_STDIO_HELPER": "1",
+		},
+	})
+	reg.Manifest.Actions["check"] = ActionSpec{
+		Inputs:  map[string]FieldSpec{},
+		Outputs: map[string]FieldSpec{},
+	}
+
+	factory := DefaultAdapterFactory{NativeLookup: LookupBuiltinNativeTool}
+	adapter, err := factory.New(reg)
+	if err != nil {
+		t.Fatalf("factory.New() error = %v", err)
+	}
+
+	resp, err := invokeViaAdapter(context.Background(), adapter, InvokeRequest{Action: "check"})
+	if err != nil {
+		t.Fatalf("invokeViaAdapter() error = %v", err)
+	}
+	if got := resp.Outputs["ok"]; got != true {
+		t.Fatalf("outputs[ok] = %v, want true", got)
+	}
+}
+
+func invokeViaAdapter(ctx context.Context, adapter Adapter, req InvokeRequest) (InvokeResponse, error) {
+	defer adapter.Close(ctx)
+	return adapter.Invoke(ctx, req)
+}

--- a/tool/adapter_response.go
+++ b/tool/adapter_response.go
@@ -1,0 +1,60 @@
+package tool
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+const defaultAdapterTimeout = 30 * time.Second
+
+func timeoutFromRegistration(reg Registration) time.Duration {
+	if reg.Manifest.Transport.TimeoutMS <= 0 {
+		return defaultAdapterTimeout
+	}
+	return time.Duration(reg.Manifest.Transport.TimeoutMS) * time.Millisecond
+}
+
+func decodeInvokeResponse(raw []byte, fallbackDuration int64) (InvokeResponse, error) {
+	if len(strings.TrimSpace(string(raw))) == 0 {
+		return InvokeResponse{DurationMS: fallbackDuration}, nil
+	}
+
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return InvokeResponse{}, fmt.Errorf("tool: decode invoke response: %w", err)
+	}
+
+	resp := InvokeResponse{
+		DurationMS: fallbackDuration,
+	}
+
+	if outputsRaw, hasOutputs := obj["outputs"]; hasOutputs {
+		outputs, ok := outputsRaw.(map[string]any)
+		if !ok {
+			return InvokeResponse{}, fmt.Errorf("tool: invoke response outputs must be an object")
+		}
+		resp.Outputs = outputs
+	} else {
+		resp.Outputs = obj
+	}
+
+	if metadataRaw, ok := obj["metadata"]; ok {
+		metadata, ok := metadataRaw.(map[string]any)
+		if !ok {
+			return InvokeResponse{}, fmt.Errorf("tool: invoke response metadata must be an object")
+		}
+		resp.Metadata = metadata
+	}
+
+	if durationRaw, ok := obj["duration_ms"]; ok {
+		duration, ok := asInteger(durationRaw)
+		if !ok || duration < 0 {
+			return InvokeResponse{}, fmt.Errorf("tool: invoke response duration_ms must be a non-negative integer")
+		}
+		resp.DurationMS = duration
+	}
+
+	return resp, nil
+}

--- a/tool/builtins.go
+++ b/tool/builtins.go
@@ -1,0 +1,217 @@
+package tool
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"slices"
+	"strings"
+	"text/template"
+)
+
+var builtinNativeTools = map[string]NativeTool{
+	"http_fetch":      httpFetchTool{},
+	"template_render": templateRenderTool{},
+}
+
+// BuiltinRegistrations returns all built-in native tool registrations.
+func BuiltinRegistrations() []ToolRegistration {
+	names := make([]string, 0, len(builtinNativeTools))
+	for name := range builtinNativeTools {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	regs := make([]ToolRegistration, 0, len(names))
+	for _, name := range names {
+		regs = append(regs, ToolRegistration{
+			Name:     name,
+			Origin:   OriginNative,
+			Manifest: builtinNativeTools[name].Manifest(),
+			Status:   StatusReady,
+			Enabled:  true,
+		})
+	}
+	return regs
+}
+
+// BuiltinRegistration returns a built-in registration by name.
+func BuiltinRegistration(name string) (ToolRegistration, bool) {
+	tool, ok := builtinNativeTools[name]
+	if !ok {
+		return ToolRegistration{}, false
+	}
+
+	return ToolRegistration{
+		Name:     name,
+		Origin:   OriginNative,
+		Manifest: tool.Manifest(),
+		Status:   StatusReady,
+		Enabled:  true,
+	}, true
+}
+
+// LookupBuiltinNativeTool returns a native built-in tool implementation by name.
+func LookupBuiltinNativeTool(name string) (NativeTool, bool) {
+	t, ok := builtinNativeTools[name]
+	return t, ok
+}
+
+type templateRenderTool struct{}
+
+func (templateRenderTool) Name() string {
+	return "template_render"
+}
+
+func (templateRenderTool) Manifest() Manifest {
+	manifest := NewManifest("template_render")
+	manifest.Tool.Description = "Render a Go template string with provided variables."
+	manifest.Tool.Version = "built-in"
+	manifest.Transport = NewNativeTransport()
+	manifest.Actions = map[string]ActionSpec{
+		"render": {
+			Description: "Render template content into a final string.",
+			Inputs: map[string]FieldSpec{
+				"template": {Type: TypeString, Required: true},
+				"values": {
+					Type:        TypeObject,
+					Description: "Optional object of template values.",
+				},
+			},
+			Outputs: map[string]FieldSpec{
+				"rendered": {Type: TypeString},
+			},
+			Idempotent: true,
+		},
+	}
+	return manifest
+}
+
+func (templateRenderTool) Invoke(ctx context.Context, action string, inputs map[string]any, config map[string]any) (map[string]any, error) {
+	if action != "render" {
+		return nil, fmt.Errorf("%w: %s", ErrActionNotFound, action)
+	}
+
+	templateBody, _ := inputs["template"].(string)
+	if strings.TrimSpace(templateBody) == "" {
+		return nil, fmt.Errorf("template_render: template input is required")
+	}
+
+	values := make(map[string]any)
+	if explicitValues, ok := inputs["values"].(map[string]any); ok {
+		for k, v := range explicitValues {
+			values[k] = v
+		}
+	}
+	for key, value := range inputs {
+		if key == "template" || key == "values" {
+			continue
+		}
+		values[key] = value
+	}
+
+	tpl, err := template.New("template_render").Option("missingkey=zero").Parse(templateBody)
+	if err != nil {
+		return nil, fmt.Errorf("template_render: parse template: %w", err)
+	}
+
+	var out bytes.Buffer
+	if err := tpl.Execute(&out, values); err != nil {
+		return nil, fmt.Errorf("template_render: execute template: %w", err)
+	}
+
+	return map[string]any{
+		"rendered": out.String(),
+	}, nil
+}
+
+type httpFetchTool struct{}
+
+func (httpFetchTool) Name() string {
+	return "http_fetch"
+}
+
+func (httpFetchTool) Manifest() Manifest {
+	manifest := NewManifest("http_fetch")
+	manifest.Tool.Description = "Fetch a URL over HTTP(S) and return status/body."
+	manifest.Tool.Version = "built-in"
+	manifest.Transport = NewNativeTransport()
+	manifest.Actions = map[string]ActionSpec{
+		"fetch": {
+			Description: "Execute an HTTP request and return response data.",
+			Inputs: map[string]FieldSpec{
+				"url":    {Type: TypeString, Required: true},
+				"method": {Type: TypeString},
+				"body":   {Type: TypeString},
+			},
+			Outputs: map[string]FieldSpec{
+				"status_code": {Type: TypeInteger},
+				"body":        {Type: TypeString},
+				"headers":     {Type: TypeObject},
+			},
+			Idempotent: false,
+		},
+	}
+	manifest.Config = map[string]FieldSpec{
+		"authorization": {
+			Type:        TypeString,
+			Sensitive:   true,
+			Description: "Optional Authorization header value.",
+		},
+	}
+	return manifest
+}
+
+func (httpFetchTool) Invoke(ctx context.Context, action string, inputs map[string]any, config map[string]any) (map[string]any, error) {
+	if action != "fetch" {
+		return nil, fmt.Errorf("%w: %s", ErrActionNotFound, action)
+	}
+
+	urlValue, _ := inputs["url"].(string)
+	if strings.TrimSpace(urlValue) == "" {
+		return nil, fmt.Errorf("http_fetch: url input is required")
+	}
+
+	method := http.MethodGet
+	if rawMethod, ok := inputs["method"].(string); ok && strings.TrimSpace(rawMethod) != "" {
+		method = strings.ToUpper(strings.TrimSpace(rawMethod))
+	}
+
+	var bodyReader io.Reader
+	if body, ok := inputs["body"].(string); ok && body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, urlValue, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("http_fetch: build request: %w", err)
+	}
+
+	if auth, ok := config["authorization"].(string); ok && strings.TrimSpace(auth) != "" {
+		req.Header.Set("Authorization", auth)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("http_fetch: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("http_fetch: read response: %w", err)
+	}
+
+	headers := make(map[string]any, len(resp.Header))
+	for key, values := range resp.Header {
+		headers[key] = strings.Join(values, ", ")
+	}
+
+	return map[string]any{
+		"status_code": resp.StatusCode,
+		"body":        string(respBody),
+		"headers":     headers,
+	}, nil
+}

--- a/tool/builtins_test.go
+++ b/tool/builtins_test.go
@@ -1,0 +1,90 @@
+package tool
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestBuiltinRegistrationsIncludePhaseOneNativeTools(t *testing.T) {
+	regs := BuiltinRegistrations()
+
+	if len(regs) < 2 {
+		t.Fatalf("len(BuiltinRegistrations) = %d, want >= 2", len(regs))
+	}
+
+	names := map[string]ToolRegistration{}
+	for _, reg := range regs {
+		names[reg.Name] = reg
+	}
+
+	for _, name := range []string{"template_render", "http_fetch"} {
+		reg, ok := names[name]
+		if !ok {
+			t.Fatalf("missing built-in registration %q", name)
+		}
+		if reg.Origin != OriginNative {
+			t.Fatalf("%s origin = %q, want %q", name, reg.Origin, OriginNative)
+		}
+		if reg.Manifest.Transport.Type != TransportTypeNative {
+			t.Fatalf("%s transport = %q, want %q", name, reg.Manifest.Transport.Type, TransportTypeNative)
+		}
+	}
+}
+
+func TestTemplateRenderBuiltinInvoke(t *testing.T) {
+	native, ok := LookupBuiltinNativeTool("template_render")
+	if !ok {
+		t.Fatal("LookupBuiltinNativeTool(template_render) = false")
+	}
+
+	adapter := NewNativeAdapter(native)
+	resp, err := adapter.Invoke(context.Background(), InvokeRequest{
+		Action: "render",
+		Inputs: map[string]any{
+			"template": "Hello, {{.name}}!",
+			"name":     "Ada",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	if got := resp.Outputs["rendered"]; got != "Hello, Ada!" {
+		t.Fatalf("outputs[rendered] = %v, want %q", got, "Hello, Ada!")
+	}
+}
+
+func TestHTTPFetchBuiltinInvoke(t *testing.T) {
+	prevTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("ok")),
+			Header:     make(http.Header),
+		}, nil
+	})
+	t.Cleanup(func() {
+		http.DefaultTransport = prevTransport
+	})
+
+	native, ok := LookupBuiltinNativeTool("http_fetch")
+	if !ok {
+		t.Fatal("LookupBuiltinNativeTool(http_fetch) = false")
+	}
+
+	adapter := NewNativeAdapter(native)
+	resp, err := adapter.Invoke(context.Background(), InvokeRequest{
+		Action: "fetch",
+		Inputs: map[string]any{
+			"url": "http://unit-test.local/ok",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	if got := resp.Outputs["status_code"]; got != 200 {
+		t.Fatalf("outputs[status_code] = %v, want 200", got)
+	}
+}

--- a/tool/doc.go
+++ b/tool/doc.go
@@ -7,6 +7,6 @@
 //   - validate: validation diagnostics and pipelines
 //   - health: health check status models and probing contracts
 //
-// This package currently provides skeleton interfaces and data models that
-// subsequent implementation tasks will fill in.
+// The package is intentionally transport-agnostic so CLI, daemon, and runtime
+// paths can share one manifest/registration contract.
 package tool

--- a/tool/http_adapter.go
+++ b/tool/http_adapter.go
@@ -1,22 +1,86 @@
 package tool
 
-import "context"
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
 
 // HTTPAdapter is the runtime adapter for HTTP-backed tools.
 type HTTPAdapter struct {
-	reg Registration
+	reg    Registration
+	client *http.Client
 }
 
 // NewHTTPAdapter creates an HTTP adapter from a registration.
 func NewHTTPAdapter(reg Registration) *HTTPAdapter {
-	return &HTTPAdapter{reg: reg}
+	return &HTTPAdapter{
+		reg:    reg,
+		client: &http.Client{Timeout: timeoutFromRegistration(reg)},
+	}
 }
 
 // Invoke executes an action over HTTP.
-//
-// Implementation is intentionally deferred to follow-up tasks.
 func (a *HTTPAdapter) Invoke(ctx context.Context, req InvokeRequest) (InvokeResponse, error) {
-	return InvokeResponse{}, ErrNotImplemented
+	if a == nil {
+		return InvokeResponse{}, fmt.Errorf("tool: http adapter is nil")
+	}
+	endpoint := strings.TrimSpace(a.reg.Manifest.Transport.Endpoint)
+	if endpoint == "" {
+		return InvokeResponse{}, fmt.Errorf("tool: http adapter endpoint is empty")
+	}
+	if strings.TrimSpace(req.Action) == "" {
+		return InvokeResponse{}, fmt.Errorf("%w: empty action", ErrActionNotFound)
+	}
+
+	payload := map[string]any{
+		"tool_name":   req.ToolName,
+		"action":      req.Action,
+		"inputs":      req.Inputs,
+		"config":      req.Config,
+		"request_id":  req.RequestID,
+		"transport":   string(a.reg.Manifest.Transport.Type),
+		"tool_origin": string(a.reg.Origin),
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return InvokeResponse{}, fmt.Errorf("tool: encode HTTP invoke request: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return InvokeResponse{}, fmt.Errorf("tool: build HTTP request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("Accept", "application/json")
+
+	start := time.Now()
+	resp, err := a.client.Do(httpReq)
+	if err != nil {
+		return InvokeResponse{}, fmt.Errorf("tool: HTTP invoke failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return InvokeResponse{}, fmt.Errorf("tool: read HTTP response: %w", err)
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		message := strings.TrimSpace(string(respBody))
+		if message == "" {
+			message = http.StatusText(resp.StatusCode)
+		}
+		return InvokeResponse{}, fmt.Errorf("tool: HTTP invoke returned status %d: %s", resp.StatusCode, message)
+	}
+
+	return decodeInvokeResponse(respBody, elapsedMS(start))
 }
 
 // Close releases any adapter resources.

--- a/tool/http_adapter_test.go
+++ b/tool/http_adapter_test.go
@@ -1,0 +1,94 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestHTTPAdapterInvoke(t *testing.T) {
+	adapterResponse := `{"outputs":{"ok":true},"duration_ms":42}`
+	reg := ToolRegistration{
+		Name:     "echo_http",
+		Origin:   OriginHTTP,
+		Manifest: NewManifest("echo_http"),
+	}
+	reg.Manifest.Transport = NewHTTPTransport(HTTPTransport{
+		Endpoint: "http://unit-test.local/echo",
+	})
+
+	adapter := NewHTTPAdapter(reg)
+	adapter.client = &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			if r.Method != http.MethodPost {
+				t.Fatalf("method = %s, want POST", r.Method)
+			}
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Fatalf("decode payload: %v", err)
+			}
+			if payload["action"] != "echo" {
+				t.Fatalf("payload action = %v, want echo", payload["action"])
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(adapterResponse)),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	resp, err := adapter.Invoke(context.Background(), InvokeRequest{
+		ToolName: "echo_http",
+		Action:   "echo",
+		Inputs: map[string]any{
+			"value": "hello",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	if got := resp.Outputs["ok"]; got != true {
+		t.Fatalf("outputs[ok] = %v, want true", got)
+	}
+	if resp.DurationMS != 42 {
+		t.Fatalf("DurationMS = %d, want 42", resp.DurationMS)
+	}
+}
+
+func TestHTTPAdapterInvokeStatusError(t *testing.T) {
+	reg := ToolRegistration{
+		Name:     "echo_http",
+		Origin:   OriginHTTP,
+		Manifest: NewManifest("echo_http"),
+	}
+	reg.Manifest.Transport = NewHTTPTransport(HTTPTransport{
+		Endpoint: "http://unit-test.local/echo",
+	})
+
+	adapter := NewHTTPAdapter(reg)
+	adapter.client = &http.Client{
+		Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusBadGateway,
+				Body:       io.NopCloser(strings.NewReader("downstream failure")),
+				Header:     make(http.Header),
+			}, nil
+		}),
+	}
+
+	_, err := adapter.Invoke(context.Background(), InvokeRequest{Action: "echo"})
+	if err == nil {
+		t.Fatal("Invoke() error = nil, want non-nil")
+	}
+}
+
+type roundTripFunc func(r *http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}

--- a/tool/manifest.go
+++ b/tool/manifest.go
@@ -12,9 +12,10 @@ const (
 type TransportType string
 
 const (
-	TransportTypeHTTP  TransportType = "http"
-	TransportTypeStdio TransportType = "stdio"
-	TransportTypeMCP   TransportType = "mcp"
+	TransportTypeNative TransportType = "native"
+	TransportTypeHTTP   TransportType = "http"
+	TransportTypeStdio  TransportType = "stdio"
+	TransportTypeMCP    TransportType = "mcp"
 )
 
 // MCPMode defines how an MCP server is connected.
@@ -147,6 +148,13 @@ func NewHTTPTransport(cfg HTTPTransport) TransportSpec {
 		Endpoint:  cfg.Endpoint,
 		TimeoutMS: cfg.TimeoutMS,
 		Retry:     cfg.Retry,
+	}
+}
+
+// NewNativeTransport creates a transport specification for in-process tools.
+func NewNativeTransport() TransportSpec {
+	return TransportSpec{
+		Type: TransportTypeNative,
 	}
 }
 

--- a/tool/manifest_schema.go
+++ b/tool/manifest_schema.go
@@ -157,9 +157,9 @@ func (v *manifestSchemaValidator) validateTransport(obj map[string]any) {
 	}
 
 	switch TransportType(transportType) {
-	case TransportTypeHTTP, TransportTypeStdio, TransportTypeMCP:
+	case TransportTypeNative, TransportTypeHTTP, TransportTypeStdio, TransportTypeMCP:
 	default:
-		v.add("transport.type", "ENUM", "must be one of: http, stdio, mcp")
+		v.add("transport.type", "ENUM", "must be one of: native, http, stdio, mcp")
 	}
 
 	if timeoutRaw, ok := obj["timeout_ms"]; ok {
@@ -216,6 +216,8 @@ func (v *manifestSchemaValidator) validateTransport(obj map[string]any) {
 	}
 
 	switch TransportType(transportType) {
+	case TransportTypeNative:
+		// Native tools are invoked in-process and require no transport endpoint fields.
 	case TransportTypeHTTP:
 		endpoint, ok := v.requireString(obj, "endpoint", "transport.endpoint")
 		if ok && strings.TrimSpace(endpoint) == "" {

--- a/tool/manifest_test.go
+++ b/tool/manifest_test.go
@@ -53,6 +53,10 @@ func TestToolManifestJSONRoundTrip(t *testing.T) {
 		transport TransportSpec
 	}{
 		{
+			name:      "native",
+			transport: NewNativeTransport(),
+		},
+		{
 			name: "http",
 			transport: NewHTTPTransport(HTTPTransport{
 				Endpoint:  "http://localhost:9801",

--- a/tool/registration_validation.go
+++ b/tool/registration_validation.go
@@ -1,0 +1,340 @@
+package tool
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+var toolNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]{1,63}$`)
+
+const (
+	// RegistrationValidationFailedCode identifies aggregated registration failures.
+	RegistrationValidationFailedCode = "REGISTRATION_VALIDATION_FAILED"
+)
+
+// RegistrationValidationError is a structured validation error payload.
+type RegistrationValidationError struct {
+	Code    string       `json:"code"`
+	Message string       `json:"message"`
+	Details []Diagnostic `json:"details"`
+}
+
+func (e *RegistrationValidationError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// ReachabilityChecker validates transport connectivity for registrations.
+type ReachabilityChecker interface {
+	CheckHTTP(ctx context.Context, endpoint string) error
+	CheckStdio(ctx context.Context, command string) error
+	CheckMCP(ctx context.Context, reg Registration) error
+}
+
+// DefaultReachabilityChecker validates transport reachability using local probes.
+type DefaultReachabilityChecker struct{}
+
+func (DefaultReachabilityChecker) CheckHTTP(ctx context.Context, endpoint string) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("invalid endpoint: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= http.StatusBadRequest {
+		return fmt.Errorf("received HTTP %d", resp.StatusCode)
+	}
+	return nil
+}
+
+func (DefaultReachabilityChecker) CheckStdio(ctx context.Context, command string) error {
+	_, err := exec.LookPath(command)
+	return err
+}
+
+func (DefaultReachabilityChecker) CheckMCP(ctx context.Context, reg Registration) error {
+	return errors.New("mcp reachability check is not implemented")
+}
+
+// RegistrationValidationOptions configures validation behavior.
+type RegistrationValidationOptions struct {
+	Store               Store
+	ReachabilityChecker ReachabilityChecker
+	AllowExistingName   bool
+}
+
+// ValidateNewRegistration validates a registration against manifest and policy.
+func ValidateNewRegistration(ctx context.Context, reg Registration, opts RegistrationValidationOptions) error {
+	if opts.ReachabilityChecker == nil {
+		opts.ReachabilityChecker = DefaultReachabilityChecker{}
+	}
+
+	var pipeline Pipeline
+	pipeline.AddManifestValidator(SchemaManifestValidator{})
+	pipeline.AddManifestValidator(V1TypeSystemValidator{})
+	pipeline.AddRegistrationValidator(RegistrationNameValidator{
+		Store:         opts.Store,
+		RequireUnique: !opts.AllowExistingName,
+	})
+	pipeline.AddRegistrationValidator(ActionNameValidator{})
+	pipeline.AddRegistrationValidator(TransportReachabilityValidator{
+		Checker: opts.ReachabilityChecker,
+	})
+	pipeline.AddRegistrationValidator(ConfigCompletenessValidator{})
+	pipeline.AddRegistrationValidator(SensitiveFieldValidator{})
+
+	manifestResult := pipeline.ValidateManifest(reg.Manifest)
+	registrationResult := pipeline.ValidateRegistration(reg)
+	diags := append(manifestResult.Diagnostics, registrationResult.Diagnostics...)
+
+	if !hasValidationErrors(diags) {
+		return nil
+	}
+
+	return &RegistrationValidationError{
+		Code:    RegistrationValidationFailedCode,
+		Message: "Tool registration failed validation",
+		Details: diags,
+	}
+}
+
+// RegistrationNameValidator validates tool names and uniqueness constraints.
+type RegistrationNameValidator struct {
+	Store         Store
+	RequireUnique bool
+}
+
+func (v RegistrationNameValidator) ValidateRegistration(reg Registration) []Diagnostic {
+	diags := make([]Diagnostic, 0)
+	name := strings.TrimSpace(reg.Name)
+	if name == "" {
+		return append(diags, Diagnostic{
+			Field:    "name",
+			Code:     "REQUIRED_FIELD",
+			Severity: SeverityError,
+			Message:  "Tool name is required",
+		})
+	}
+
+	if !toolNamePattern.MatchString(name) {
+		diags = append(diags, Diagnostic{
+			Field:    "name",
+			Code:     "INVALID_NAME",
+			Severity: SeverityError,
+			Message:  "Tool name must match ^[a-z][a-z0-9_]{1,63}$",
+		})
+	}
+
+	if v.Store != nil && v.RequireUnique {
+		if _, exists, err := v.Store.Get(context.Background(), name); err != nil {
+			diags = append(diags, Diagnostic{
+				Field:    "name",
+				Code:     "STORE_LOOKUP_FAILED",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("Failed to verify name uniqueness: %v", err),
+			})
+		} else if exists {
+			diags = append(diags, Diagnostic{
+				Field:    "name",
+				Code:     "NAME_NOT_UNIQUE",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("Tool name %q is already registered", name),
+			})
+		}
+	}
+
+	return diags
+}
+
+// ActionNameValidator validates action naming and uniqueness.
+type ActionNameValidator struct{}
+
+func (ActionNameValidator) ValidateRegistration(reg Registration) []Diagnostic {
+	diags := make([]Diagnostic, 0)
+	seen := make(map[string]string)
+
+	if len(reg.Manifest.Actions) == 0 {
+		diags = append(diags, Diagnostic{
+			Field:    "actions",
+			Code:     "REQUIRED_FIELD",
+			Severity: SeverityError,
+			Message:  "At least one action is required",
+		})
+		return diags
+	}
+
+	for actionName := range reg.Manifest.Actions {
+		clean := strings.TrimSpace(actionName)
+		if clean == "" {
+			diags = append(diags, Diagnostic{
+				Field:    "actions",
+				Code:     "INVALID_ACTION_NAME",
+				Severity: SeverityError,
+				Message:  "Action names must not be empty",
+			})
+			continue
+		}
+		if !toolNamePattern.MatchString(clean) {
+			diags = append(diags, Diagnostic{
+				Field:    "actions." + clean,
+				Code:     "INVALID_ACTION_NAME",
+				Severity: SeverityError,
+				Message:  "Action name must match ^[a-z][a-z0-9_]{1,63}$",
+			})
+		}
+
+		lower := strings.ToLower(clean)
+		if prev, exists := seen[lower]; exists && prev != clean {
+			diags = append(diags, Diagnostic{
+				Field:    "actions." + clean,
+				Code:     "ACTION_NOT_UNIQUE",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("Action name %q conflicts with %q", clean, prev),
+			})
+			continue
+		}
+		seen[lower] = clean
+	}
+
+	return diags
+}
+
+// TransportReachabilityValidator verifies transport-specific connectivity.
+type TransportReachabilityValidator struct {
+	Checker ReachabilityChecker
+}
+
+func (v TransportReachabilityValidator) ValidateRegistration(reg Registration) []Diagnostic {
+	checker := v.Checker
+	if checker == nil {
+		checker = DefaultReachabilityChecker{}
+	}
+
+	switch reg.Manifest.Transport.Type {
+	case TransportTypeNative:
+		return nil
+	case TransportTypeHTTP:
+		endpoint := strings.TrimSpace(reg.Manifest.Transport.Endpoint)
+		if endpoint == "" {
+			return []Diagnostic{{
+				Field:    "transport.endpoint",
+				Code:     "REQUIRED_FIELD",
+				Severity: SeverityError,
+				Message:  "HTTP transport requires endpoint",
+			}}
+		}
+		if err := checker.CheckHTTP(context.Background(), endpoint); err != nil {
+			return []Diagnostic{{
+				Field:    "transport.endpoint",
+				Code:     "UNREACHABLE",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("Could not connect to %s", endpoint),
+			}}
+		}
+	case TransportTypeStdio:
+		command := strings.TrimSpace(reg.Manifest.Transport.Command)
+		if command == "" {
+			return []Diagnostic{{
+				Field:    "transport.command",
+				Code:     "REQUIRED_FIELD",
+				Severity: SeverityError,
+				Message:  "Stdio transport requires command",
+			}}
+		}
+		if err := checker.CheckStdio(context.Background(), command); err != nil {
+			return []Diagnostic{{
+				Field:    "transport.command",
+				Code:     "UNREACHABLE",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("Command %q is not executable", command),
+			}}
+		}
+	case TransportTypeMCP:
+		if err := checker.CheckMCP(context.Background(), reg); err != nil {
+			return []Diagnostic{{
+				Field:    "transport",
+				Code:     "UNREACHABLE",
+				Severity: SeverityError,
+				Message:  "MCP transport initialization failed",
+			}}
+		}
+	default:
+		return []Diagnostic{{
+			Field:    "transport.type",
+			Code:     "INVALID_TRANSPORT",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("Unsupported transport type %q", reg.Manifest.Transport.Type),
+		}}
+	}
+
+	return nil
+}
+
+// ConfigCompletenessValidator enforces required config field values.
+type ConfigCompletenessValidator struct{}
+
+func (ConfigCompletenessValidator) ValidateRegistration(reg Registration) []Diagnostic {
+	diags := make([]Diagnostic, 0)
+	for key, spec := range reg.Manifest.Config {
+		if !spec.Required {
+			continue
+		}
+
+		value := strings.TrimSpace(reg.Config[key])
+		if value != "" {
+			continue
+		}
+
+		diags = append(diags, Diagnostic{
+			Field:    "config." + key,
+			Code:     "REQUIRED_FIELD",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("Required config field %q has no value", key),
+		})
+	}
+	return diags
+}
+
+// SensitiveFieldValidator enforces secure sensitive field declarations.
+type SensitiveFieldValidator struct{}
+
+func (SensitiveFieldValidator) ValidateRegistration(reg Registration) []Diagnostic {
+	diags := make([]Diagnostic, 0)
+	for key, spec := range reg.Manifest.Config {
+		if !spec.Sensitive {
+			continue
+		}
+		if spec.Default == nil {
+			continue
+		}
+
+		diags = append(diags, Diagnostic{
+			Field:    "config." + key + ".default",
+			Code:     "SENSITIVE_DEFAULT_FORBIDDEN",
+			Severity: SeverityError,
+			Message:  fmt.Sprintf("Sensitive config field %q must not define a default", key),
+		})
+	}
+	return diags
+}
+
+func hasValidationErrors(diags []Diagnostic) bool {
+	for _, diag := range diags {
+		if diag.Severity == SeverityError {
+			return true
+		}
+	}
+	return false
+}

--- a/tool/registration_validation_test.go
+++ b/tool/registration_validation_test.go
@@ -1,0 +1,213 @@
+package tool
+
+import (
+	"context"
+	"errors"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+type stubReachabilityChecker struct {
+	httpErr  error
+	stdioErr error
+	mcpErr   error
+}
+
+func (s stubReachabilityChecker) CheckHTTP(ctx context.Context, endpoint string) error {
+	return s.httpErr
+}
+
+func (s stubReachabilityChecker) CheckStdio(ctx context.Context, command string) error {
+	return s.stdioErr
+}
+
+func (s stubReachabilityChecker) CheckMCP(ctx context.Context, reg Registration) error {
+	return s.mcpErr
+}
+
+func TestValidateNewRegistrationSuccess(t *testing.T) {
+	store := NewFileStore(filepath.Join(t.TempDir(), "tools.json"))
+	reg := ToolRegistration{
+		Name:     "http_probe",
+		Origin:   OriginHTTP,
+		Manifest: NewManifest("http_probe"),
+		Config: map[string]string{
+			"token": "abc",
+		},
+	}
+	reg.Manifest.Transport = NewHTTPTransport(HTTPTransport{Endpoint: "http://localhost:9801"})
+	reg.Manifest.Actions["check"] = ActionSpec{
+		Inputs: map[string]FieldSpec{
+			"path": {Type: TypeString},
+		},
+		Outputs: map[string]FieldSpec{
+			"ok": {Type: TypeBoolean},
+		},
+	}
+	reg.Manifest.Config = map[string]FieldSpec{
+		"token": {Type: TypeString, Required: true, Sensitive: true},
+	}
+
+	err := ValidateNewRegistration(context.Background(), reg, RegistrationValidationOptions{
+		Store:               store,
+		ReachabilityChecker: stubReachabilityChecker{},
+	})
+	if err != nil {
+		t.Fatalf("ValidateNewRegistration() error = %v", err)
+	}
+}
+
+func TestValidateNewRegistrationInvalidName(t *testing.T) {
+	reg := ToolRegistration{
+		Name:     "Bad Name",
+		Origin:   OriginNative,
+		Manifest: NewManifest("Bad Name"),
+	}
+	reg.Manifest.Transport = NewNativeTransport()
+	reg.Manifest.Actions["execute"] = ActionSpec{
+		Inputs:  map[string]FieldSpec{},
+		Outputs: map[string]FieldSpec{},
+	}
+
+	err := ValidateNewRegistration(context.Background(), reg, RegistrationValidationOptions{
+		ReachabilityChecker: stubReachabilityChecker{},
+	})
+	var validationErr *RegistrationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error type = %T, want *RegistrationValidationError", err)
+	}
+
+	if validationErr.Code != RegistrationValidationFailedCode {
+		t.Fatalf("Code = %q, want %q", validationErr.Code, RegistrationValidationFailedCode)
+	}
+
+	fields := validationFields(validationErr.Details)
+	if !slices.Contains(fields, "name") {
+		t.Fatalf("expected name diagnostic, got %v", fields)
+	}
+}
+
+func TestValidateNewRegistrationDuplicateName(t *testing.T) {
+	store := NewFileStore(filepath.Join(t.TempDir(), "tools.json"))
+	existing := ToolRegistration{
+		Name:     "duplicate_tool",
+		Origin:   OriginNative,
+		Manifest: NewManifest("duplicate_tool"),
+		Status:   StatusReady,
+	}
+	existing.Manifest.Transport = NewNativeTransport()
+	existing.Manifest.Actions["execute"] = ActionSpec{
+		Inputs:  map[string]FieldSpec{},
+		Outputs: map[string]FieldSpec{},
+	}
+	if err := store.Upsert(context.Background(), existing); err != nil {
+		t.Fatalf("Upsert() error = %v", err)
+	}
+
+	reg := existing
+	err := ValidateNewRegistration(context.Background(), reg, RegistrationValidationOptions{
+		Store:               store,
+		ReachabilityChecker: stubReachabilityChecker{},
+	})
+	if err == nil {
+		t.Fatal("ValidateNewRegistration() error = nil, want non-nil")
+	}
+	var validationErr *RegistrationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error type = %T, want *RegistrationValidationError", err)
+	}
+	if !slices.Contains(validationCodes(validationErr.Details), "NAME_NOT_UNIQUE") {
+		t.Fatalf("expected NAME_NOT_UNIQUE, got %v", validationCodes(validationErr.Details))
+	}
+}
+
+func TestValidateNewRegistrationConfigCompletenessAndSensitiveDefaults(t *testing.T) {
+	reg := ToolRegistration{
+		Name:     "secure_tool",
+		Origin:   OriginNative,
+		Manifest: NewManifest("secure_tool"),
+		Config:   map[string]string{},
+	}
+	reg.Manifest.Transport = NewNativeTransport()
+	reg.Manifest.Actions["execute"] = ActionSpec{
+		Inputs:  map[string]FieldSpec{},
+		Outputs: map[string]FieldSpec{},
+	}
+	reg.Manifest.Config = map[string]FieldSpec{
+		"credentials": {
+			Type:      TypeString,
+			Required:  true,
+			Sensitive: true,
+			Default:   "do-not-allow",
+		},
+	}
+
+	err := ValidateNewRegistration(context.Background(), reg, RegistrationValidationOptions{
+		ReachabilityChecker: stubReachabilityChecker{},
+	})
+	if err == nil {
+		t.Fatal("ValidateNewRegistration() error = nil, want non-nil")
+	}
+	var validationErr *RegistrationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error type = %T, want *RegistrationValidationError", err)
+	}
+
+	codes := validationCodes(validationErr.Details)
+	if !slices.Contains(codes, "REQUIRED_FIELD") {
+		t.Fatalf("expected REQUIRED_FIELD, got %v", codes)
+	}
+	if !slices.Contains(codes, "SENSITIVE_DEFAULT_FORBIDDEN") {
+		t.Fatalf("expected SENSITIVE_DEFAULT_FORBIDDEN, got %v", codes)
+	}
+
+	for _, detail := range validationErr.Details {
+		if detail.Field == "config.credentials" && detail.Message == "do-not-allow" {
+			t.Fatalf("sensitive default leaked in message: %q", detail.Message)
+		}
+	}
+}
+
+func TestValidateNewRegistrationTransportUnreachable(t *testing.T) {
+	reg := ToolRegistration{
+		Name:     "http_down",
+		Origin:   OriginHTTP,
+		Manifest: NewManifest("http_down"),
+	}
+	reg.Manifest.Transport = NewHTTPTransport(HTTPTransport{Endpoint: "http://localhost:9999"})
+	reg.Manifest.Actions["check"] = ActionSpec{
+		Inputs:  map[string]FieldSpec{},
+		Outputs: map[string]FieldSpec{},
+	}
+
+	err := ValidateNewRegistration(context.Background(), reg, RegistrationValidationOptions{
+		ReachabilityChecker: stubReachabilityChecker{httpErr: errors.New("connection refused")},
+	})
+	if err == nil {
+		t.Fatal("ValidateNewRegistration() error = nil, want non-nil")
+	}
+	var validationErr *RegistrationValidationError
+	if !errors.As(err, &validationErr) {
+		t.Fatalf("error type = %T, want *RegistrationValidationError", err)
+	}
+	if !slices.Contains(validationCodes(validationErr.Details), "UNREACHABLE") {
+		t.Fatalf("expected UNREACHABLE, got %v", validationCodes(validationErr.Details))
+	}
+}
+
+func validationFields(diags []Diagnostic) []string {
+	fields := make([]string, 0, len(diags))
+	for _, d := range diags {
+		fields = append(fields, d.Field)
+	}
+	return fields
+}
+
+func validationCodes(diags []Diagnostic) []string {
+	codes := make([]string, 0, len(diags))
+	for _, d := range diags {
+		codes = append(codes, d.Code)
+	}
+	return codes
+}

--- a/tool/schemas/tool-manifest-v1.json
+++ b/tool/schemas/tool-manifest-v1.json
@@ -59,6 +59,7 @@
         "type": {
           "type": "string",
           "enum": [
+            "native",
             "http",
             "stdio",
             "mcp"

--- a/tool/stdio_adapter.go
+++ b/tool/stdio_adapter.go
@@ -1,6 +1,16 @@
 package tool
 
-import "context"
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"time"
+)
 
 // StdioAdapter is the runtime adapter for subprocess-backed tools.
 type StdioAdapter struct {
@@ -13,13 +23,102 @@ func NewStdioAdapter(reg Registration) *StdioAdapter {
 }
 
 // Invoke executes an action through a long-running subprocess transport.
-//
-// Implementation is intentionally deferred to follow-up tasks.
 func (a *StdioAdapter) Invoke(ctx context.Context, req InvokeRequest) (InvokeResponse, error) {
-	return InvokeResponse{}, ErrNotImplemented
+	if a == nil {
+		return InvokeResponse{}, fmt.Errorf("tool: stdio adapter is nil")
+	}
+	command := strings.TrimSpace(a.reg.Manifest.Transport.Command)
+	if command == "" {
+		return InvokeResponse{}, fmt.Errorf("tool: stdio adapter command is empty")
+	}
+	if strings.TrimSpace(req.Action) == "" {
+		return InvokeResponse{}, fmt.Errorf("%w: empty action", ErrActionNotFound)
+	}
+
+	execCtx := ctx
+	timeout := timeoutFromRegistration(a.reg)
+	if _, hasDeadline := ctx.Deadline(); !hasDeadline && timeout > 0 {
+		var cancel context.CancelFunc
+		execCtx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	args := a.reg.Manifest.Transport.Args
+	// #nosec G204 -- command/args are explicitly configured by tool registration.
+	cmd := exec.CommandContext(execCtx, command, args...)
+	if len(a.reg.Manifest.Transport.Env) > 0 {
+		cmd.Env = append(os.Environ(), flattenEnv(a.reg.Manifest.Transport.Env)...)
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return InvokeResponse{}, fmt.Errorf("tool: stdio open stdin: %w", err)
+	}
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return InvokeResponse{}, fmt.Errorf("tool: stdio open stdout: %w", err)
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return InvokeResponse{}, fmt.Errorf("tool: stdio open stderr: %w", err)
+	}
+
+	start := time.Now()
+	if err := cmd.Start(); err != nil {
+		return InvokeResponse{}, fmt.Errorf("tool: stdio start command: %w", err)
+	}
+
+	payload := InvokeRequest{
+		ToolName:  req.ToolName,
+		Action:    req.Action,
+		Inputs:    req.Inputs,
+		Config:    req.Config,
+		RequestID: req.RequestID,
+	}
+	if err := json.NewEncoder(stdin).Encode(payload); err != nil {
+		_ = stdin.Close()
+		_ = cmd.Wait()
+		return InvokeResponse{}, fmt.Errorf("tool: stdio encode request: %w", err)
+	}
+	if err := stdin.Close(); err != nil {
+		_ = cmd.Wait()
+		return InvokeResponse{}, fmt.Errorf("tool: stdio close stdin: %w", err)
+	}
+
+	stdoutBytes, stdoutErr := io.ReadAll(stdout)
+	stderrBytes, _ := io.ReadAll(stderr)
+	waitErr := cmd.Wait()
+
+	if stdoutErr != nil {
+		return InvokeResponse{}, fmt.Errorf("tool: stdio read stdout: %w", stdoutErr)
+	}
+	if waitErr != nil {
+		message := strings.TrimSpace(string(stderrBytes))
+		if message == "" {
+			message = waitErr.Error()
+		}
+		return InvokeResponse{}, fmt.Errorf("tool: stdio invoke failed: %s", message)
+	}
+
+	return decodeInvokeResponse(stdoutBytes, elapsedMS(start))
 }
 
 // Close releases any adapter resources.
 func (a *StdioAdapter) Close(ctx context.Context) error {
 	return nil
+}
+
+func flattenEnv(values map[string]string) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	out := make([]string, 0, len(values))
+	for _, key := range keys {
+		value := values[key]
+		out = append(out, key+"="+value)
+	}
+	return out
 }

--- a/tool/stdio_adapter_test.go
+++ b/tool/stdio_adapter_test.go
@@ -1,0 +1,89 @@
+package tool
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestStdioAdapterInvoke(t *testing.T) {
+	reg := ToolRegistration{
+		Name:     "echo_stdio",
+		Origin:   OriginStdio,
+		Manifest: NewManifest("echo_stdio"),
+	}
+	reg.Manifest.Transport = NewStdioTransport(StdioTransport{
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestStdioAdapterHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_STDIO_HELPER": "1",
+		},
+	})
+
+	adapter := NewStdioAdapter(reg)
+	resp, err := adapter.Invoke(context.Background(), InvokeRequest{
+		ToolName: "echo_stdio",
+		Action:   "echo",
+		Inputs: map[string]any{
+			"value": "hello",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Invoke() error = %v", err)
+	}
+	if got := resp.Outputs["action"]; got != "echo" {
+		t.Fatalf("outputs[action] = %v, want echo", got)
+	}
+	if got := resp.Outputs["ok"]; got != true {
+		t.Fatalf("outputs[ok] = %v, want true", got)
+	}
+}
+
+func TestStdioAdapterInvokeError(t *testing.T) {
+	reg := ToolRegistration{
+		Name:     "echo_stdio",
+		Origin:   OriginStdio,
+		Manifest: NewManifest("echo_stdio"),
+	}
+	reg.Manifest.Transport = NewStdioTransport(StdioTransport{
+		Command: os.Args[0],
+		Args:    []string{"-test.run=TestStdioAdapterHelperProcess", "--"},
+		Env: map[string]string{
+			"GO_WANT_STDIO_HELPER": "1",
+			"GO_STDIO_HELPER_FAIL": "1",
+		},
+	})
+
+	adapter := NewStdioAdapter(reg)
+	_, err := adapter.Invoke(context.Background(), InvokeRequest{Action: "echo"})
+	if err == nil {
+		t.Fatal("Invoke() error = nil, want non-nil")
+	}
+}
+
+func TestStdioAdapterHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_STDIO_HELPER") != "1" {
+		return
+	}
+
+	if os.Getenv("GO_STDIO_HELPER_FAIL") == "1" {
+		_, _ = fmt.Fprintln(os.Stderr, "helper failed")
+		os.Exit(2)
+	}
+
+	var req InvokeRequest
+	if err := json.NewDecoder(os.Stdin).Decode(&req); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "decode error: %v\n", err)
+		os.Exit(2)
+	}
+
+	_ = json.NewEncoder(os.Stdout).Encode(map[string]any{
+		"outputs": map[string]any{
+			"ok":     true,
+			"action": req.Action,
+		},
+	})
+	os.Exit(0)
+}

--- a/tool/type_system.go
+++ b/tool/type_system.go
@@ -52,6 +52,11 @@ func (V1TypeSystemValidator) ValidateManifestTypes(manifest Manifest) []Diagnost
 	return diags
 }
 
+// ValidateManifest satisfies ManifestValidator.
+func (v V1TypeSystemValidator) ValidateManifest(manifest Manifest) []Diagnostic {
+	return v.ValidateManifestTypes(manifest)
+}
+
 // ValidateCompatibility validates a source output field against a target input field.
 //
 // When either side is typed as "any", compatibility is allowed but returns a warning.


### PR DESCRIPTION
## Summary
- implement concrete HTTPAdapter and StdioAdapter behavior with a shared default adapter factory
- add native built-ins (template_render, http_fetch) with manifest-backed registrations
- add petalflow tools CLI with register, list, inspect, unregister, config, and test
- implement registration validation pipeline (name/action checks, reachability, config completeness, sensitive defaults)
- add Phase 1 test coverage for adapters, built-ins, CLI flows, and validation
- publish tools quickstart + troubleshooting docs and link from README

## Validation
- go test ./tool ./cli ./cmd/petalflow

Closes #29
Closes #30
Closes #31
Closes #32
Closes #33
Closes #34
Closes #35
