### PR TITLE
P2-01: MCP client core (initialize, tools/list, tools/call, close)

### DIFF
--- a/tool/mcp/client.go
+++ b/tool/mcp/client.go
@@ -1,0 +1,218 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+const (
+	defaultProtocolVersion = "2025-06-18"
+	defaultClientName      = "petalflow"
+	defaultClientVersion   = "dev"
+)
+
+// Transport is the message transport contract used by the MCP client core.
+// Transport implementations for stdio and SSE are added in subsequent tasks.
+type Transport interface {
+	Send(ctx context.Context, message Message) error
+	Receive(ctx context.Context) (Message, error)
+	Close(ctx context.Context) error
+}
+
+// Options configures client identity and capabilities.
+type Options struct {
+	ProtocolVersion string
+	ClientInfo      ClientInfo
+	Capabilities    map[string]any
+}
+
+// Client is a JSON-RPC based MCP client.
+type Client struct {
+	transport Transport
+	options   Options
+
+	mu          sync.Mutex
+	nextID      int64
+	initialized bool
+	initResult  InitializeResult
+}
+
+// NewClient returns a new MCP client for a given transport.
+func NewClient(transport Transport, options Options) *Client {
+	if options.ProtocolVersion == "" {
+		options.ProtocolVersion = defaultProtocolVersion
+	}
+	if options.ClientInfo.Name == "" {
+		options.ClientInfo.Name = defaultClientName
+	}
+	if options.ClientInfo.Version == "" {
+		options.ClientInfo.Version = defaultClientVersion
+	}
+
+	return &Client{
+		transport: transport,
+		options:   options,
+		nextID:    1,
+	}
+}
+
+// Initialize performs MCP initialize negotiation and sends initialized notification.
+func (c *Client) Initialize(ctx context.Context) (InitializeResult, error) {
+	if c == nil {
+		return InitializeResult{}, errors.New("mcp: client is nil")
+	}
+
+	c.mu.Lock()
+	alreadyInitialized := c.initialized
+	cachedResult := c.initResult
+	c.mu.Unlock()
+	if alreadyInitialized {
+		return cachedResult, nil
+	}
+
+	params := InitializeParams{
+		ProtocolVersion: c.options.ProtocolVersion,
+		Capabilities:    cloneMap(c.options.Capabilities),
+		ClientInfo:      c.options.ClientInfo,
+	}
+
+	var result InitializeResult
+	if err := c.call(ctx, "initialize", params, &result); err != nil {
+		return InitializeResult{}, err
+	}
+
+	if err := c.notify(ctx, "notifications/initialized", map[string]any{}); err != nil {
+		return InitializeResult{}, err
+	}
+
+	c.mu.Lock()
+	c.initialized = true
+	c.initResult = result
+	c.mu.Unlock()
+
+	return result, nil
+}
+
+// ListTools returns server tools from tools/list.
+func (c *Client) ListTools(ctx context.Context) (ToolsListResult, error) {
+	var result ToolsListResult
+	if err := c.call(ctx, "tools/list", map[string]any{}, &result); err != nil {
+		return ToolsListResult{}, err
+	}
+	return result, nil
+}
+
+// CallTool executes an MCP tool by name with arguments.
+func (c *Client) CallTool(ctx context.Context, params ToolsCallParams) (ToolsCallResult, error) {
+	var result ToolsCallResult
+	if err := c.call(ctx, "tools/call", params, &result); err != nil {
+		return ToolsCallResult{}, err
+	}
+	return result, nil
+}
+
+// Close sends an MCP close notification and closes the transport.
+func (c *Client) Close(ctx context.Context) error {
+	if c == nil || c.transport == nil {
+		return nil
+	}
+
+	_ = c.notify(ctx, "close", map[string]any{})
+	return c.transport.Close(ctx)
+}
+
+func (c *Client) call(ctx context.Context, method string, params any, out any) error {
+	if c == nil || c.transport == nil {
+		return &RequestError{Method: method, Err: errors.New("transport is nil")}
+	}
+
+	paramsRaw, err := marshalParams(params)
+	if err != nil {
+		return &RequestError{Method: method, Err: err}
+	}
+
+	id := c.nextRequestID()
+	request := Message{
+		JSONRPC: jsonRPCVersion,
+		ID:      id,
+		Method:  method,
+		Params:  paramsRaw,
+	}
+	if err := c.transport.Send(ctx, request); err != nil {
+		return &RequestError{Method: method, Err: err}
+	}
+
+	for {
+		response, err := c.transport.Receive(ctx)
+		if err != nil {
+			return &RequestError{Method: method, Err: err}
+		}
+		if response.JSONRPC != "" && response.JSONRPC != jsonRPCVersion {
+			return &RequestError{Method: method, Err: fmt.Errorf("unsupported jsonrpc version %q", response.JSONRPC)}
+		}
+
+		// Ignore non-response messages and responses for other request IDs.
+		if response.ID == 0 || response.ID != id {
+			continue
+		}
+
+		if response.Error != nil {
+			return &RequestError{Method: method, Err: response.Error}
+		}
+		if out == nil || len(response.Result) == 0 {
+			return nil
+		}
+		if err := json.Unmarshal(response.Result, out); err != nil {
+			return &RequestError{Method: method, Err: fmt.Errorf("decode result: %w", err)}
+		}
+		return nil
+	}
+}
+
+func (c *Client) notify(ctx context.Context, method string, params any) error {
+	if c == nil || c.transport == nil {
+		return nil
+	}
+	paramsRaw, err := marshalParams(params)
+	if err != nil {
+		return &RequestError{Method: method, Err: err}
+	}
+	return c.transport.Send(ctx, Message{
+		JSONRPC: jsonRPCVersion,
+		Method:  method,
+		Params:  paramsRaw,
+	})
+}
+
+func (c *Client) nextRequestID() int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	id := c.nextID
+	c.nextID++
+	return id
+}
+
+func marshalParams(params any) (json.RawMessage, error) {
+	if params == nil {
+		return nil, nil
+	}
+	data, err := json.Marshal(params)
+	if err != nil {
+		return nil, fmt.Errorf("encode params: %w", err)
+	}
+	return data, nil
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/tool/mcp/client_test.go
+++ b/tool/mcp/client_test.go
@@ -1,0 +1,339 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+)
+
+type mockTransport struct {
+	mu            sync.Mutex
+	closed        bool
+	sendErr       error
+	receiveErr    error
+	responses     []Message
+	notifications []Message
+	lastRequests  []Message
+	handler       func(req Message) Message
+}
+
+func (m *mockTransport) Send(ctx context.Context, message Message) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.sendErr != nil {
+		return m.sendErr
+	}
+	if message.Method != "" && message.ID == 0 {
+		m.notifications = append(m.notifications, message)
+		return nil
+	}
+
+	m.lastRequests = append(m.lastRequests, message)
+	if m.handler != nil {
+		m.responses = append(m.responses, m.handler(message))
+	}
+	return nil
+}
+
+func (m *mockTransport) Receive(ctx context.Context) (Message, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.receiveErr != nil {
+		return Message{}, m.receiveErr
+	}
+	if len(m.responses) == 0 {
+		return Message{}, errors.New("mock transport: no queued responses")
+	}
+	response := m.responses[0]
+	m.responses = m.responses[1:]
+	return response, nil
+}
+
+func (m *mockTransport) Close(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closed = true
+	return nil
+}
+
+func TestClientInitialize(t *testing.T) {
+	transport := &mockTransport{
+		handler: func(req Message) Message {
+			if req.Method != "initialize" {
+				return Message{
+					JSONRPC: jsonRPCVersion,
+					ID:      req.ID,
+					Error: &RPCError{
+						Code:    -32601,
+						Message: "method not found",
+					},
+				}
+			}
+			params := decodeParams(t, req.Params)
+			if params["protocolVersion"] != "2026-01-01" {
+				t.Fatalf("protocolVersion = %v, want 2026-01-01", params["protocolVersion"])
+			}
+			clientInfo, _ := params["clientInfo"].(map[string]any)
+			if clientInfo["name"] != "petalflow-test" {
+				t.Fatalf("clientInfo.name = %v, want petalflow-test", clientInfo["name"])
+			}
+
+			result := InitializeResult{
+				ProtocolVersion: "2026-01-01",
+				Capabilities: map[string]any{
+					"tools": map[string]any{},
+				},
+				ServerInfo: ServerInfo{
+					Name:    "mock-mcp",
+					Version: "1.0.0",
+				},
+			}
+			return Message{
+				JSONRPC: jsonRPCVersion,
+				ID:      req.ID,
+				Result:  mustJSON(t, result),
+			}
+		},
+	}
+
+	client := NewClient(transport, Options{
+		ProtocolVersion: "2026-01-01",
+		ClientInfo: ClientInfo{
+			Name:    "petalflow-test",
+			Version: "0.1.0",
+		},
+		Capabilities: map[string]any{
+			"tools": map[string]any{},
+		},
+	})
+
+	result, err := client.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("Initialize() error = %v", err)
+	}
+	if result.ServerInfo.Name != "mock-mcp" {
+		t.Fatalf("ServerInfo.Name = %q, want mock-mcp", result.ServerInfo.Name)
+	}
+
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	if len(transport.notifications) == 0 {
+		t.Fatal("expected initialized notification to be sent")
+	}
+	if transport.notifications[0].Method != "notifications/initialized" {
+		t.Fatalf("notification method = %q, want notifications/initialized", transport.notifications[0].Method)
+	}
+}
+
+func TestClientInitializeIsIdempotent(t *testing.T) {
+	callCount := 0
+	transport := &mockTransport{
+		handler: func(req Message) Message {
+			callCount++
+			result := InitializeResult{
+				ProtocolVersion: "2026-01-01",
+				ServerInfo: ServerInfo{
+					Name: "mock-mcp",
+				},
+			}
+			return Message{
+				JSONRPC: jsonRPCVersion,
+				ID:      req.ID,
+				Result:  mustJSON(t, result),
+			}
+		},
+	}
+
+	client := NewClient(transport, Options{
+		ProtocolVersion: "2026-01-01",
+		ClientInfo: ClientInfo{
+			Name: "petalflow-test",
+		},
+	})
+
+	first, err := client.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("first Initialize() error = %v", err)
+	}
+	second, err := client.Initialize(context.Background())
+	if err != nil {
+		t.Fatalf("second Initialize() error = %v", err)
+	}
+	if first.ServerInfo.Name != second.ServerInfo.Name {
+		t.Fatalf("cached initialize result mismatch: first=%q second=%q", first.ServerInfo.Name, second.ServerInfo.Name)
+	}
+	if callCount != 1 {
+		t.Fatalf("initialize call count = %d, want 1", callCount)
+	}
+}
+
+func TestClientListTools(t *testing.T) {
+	transport := &mockTransport{
+		handler: func(req Message) Message {
+			if req.Method != "tools/list" {
+				return Message{
+					JSONRPC: jsonRPCVersion,
+					ID:      req.ID,
+					Error: &RPCError{
+						Code:    -32601,
+						Message: "method not found",
+					},
+				}
+			}
+			result := ToolsListResult{
+				Tools: []Tool{
+					{
+						Name:        "list_s3_objects",
+						Description: "List objects in bucket",
+						InputSchema: map[string]any{
+							"type": "object",
+						},
+					},
+				},
+			}
+			return Message{
+				JSONRPC: jsonRPCVersion,
+				ID:      req.ID,
+				Result:  mustJSON(t, result),
+			}
+		},
+	}
+
+	client := NewClient(transport, Options{})
+	result, err := client.ListTools(context.Background())
+	if err != nil {
+		t.Fatalf("ListTools() error = %v", err)
+	}
+	if len(result.Tools) != 1 {
+		t.Fatalf("len(Tools) = %d, want 1", len(result.Tools))
+	}
+	if result.Tools[0].Name != "list_s3_objects" {
+		t.Fatalf("tool name = %q, want list_s3_objects", result.Tools[0].Name)
+	}
+}
+
+func TestClientCallTool(t *testing.T) {
+	transport := &mockTransport{
+		handler: func(req Message) Message {
+			if req.Method != "tools/call" {
+				return Message{
+					JSONRPC: jsonRPCVersion,
+					ID:      req.ID,
+					Error: &RPCError{
+						Code:    -32601,
+						Message: "method not found",
+					},
+				}
+			}
+			params := decodeParams(t, req.Params)
+			if params["name"] != "list_s3_objects" {
+				t.Fatalf("params.name = %v, want list_s3_objects", params["name"])
+			}
+
+			result := ToolsCallResult{
+				Content: []ContentBlock{
+					{
+						Type: "text",
+						Text: `{"keys":["a.pdf","b.pdf"],"count":2}`,
+					},
+				},
+			}
+			return Message{
+				JSONRPC: jsonRPCVersion,
+				ID:      req.ID,
+				Result:  mustJSON(t, result),
+			}
+		},
+	}
+
+	client := NewClient(transport, Options{})
+	result, err := client.CallTool(context.Background(), ToolsCallParams{
+		Name: "list_s3_objects",
+		Arguments: map[string]any{
+			"bucket": "reports",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool() error = %v", err)
+	}
+	if len(result.Content) != 1 {
+		t.Fatalf("len(Content) = %d, want 1", len(result.Content))
+	}
+	if result.Content[0].Type != "text" {
+		t.Fatalf("content type = %q, want text", result.Content[0].Type)
+	}
+}
+
+func TestClientRPCError(t *testing.T) {
+	transport := &mockTransport{
+		handler: func(req Message) Message {
+			return Message{
+				JSONRPC: jsonRPCVersion,
+				ID:      req.ID,
+				Error: &RPCError{
+					Code:    -32001,
+					Message: "server failure",
+				},
+			}
+		},
+	}
+
+	client := NewClient(transport, Options{})
+	_, err := client.ListTools(context.Background())
+	if err == nil {
+		t.Fatal("ListTools() error = nil, want non-nil")
+	}
+	var reqErr *RequestError
+	if !errors.As(err, &reqErr) {
+		t.Fatalf("error type = %T, want *RequestError", err)
+	}
+	var rpcErr *RPCError
+	if !errors.As(err, &rpcErr) {
+		t.Fatalf("error does not wrap *RPCError: %v", err)
+	}
+	if rpcErr.Code != -32001 {
+		t.Fatalf("rpc error code = %d, want -32001", rpcErr.Code)
+	}
+}
+
+func TestClientClose(t *testing.T) {
+	transport := &mockTransport{}
+	client := NewClient(transport, Options{})
+	if err := client.Close(context.Background()); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	transport.mu.Lock()
+	defer transport.mu.Unlock()
+	if !transport.closed {
+		t.Fatal("transport.closed = false, want true")
+	}
+	if len(transport.notifications) == 0 {
+		t.Fatal("expected close notification before transport close")
+	}
+	if transport.notifications[0].Method != "close" {
+		t.Fatalf("close notification method = %q, want close", transport.notifications[0].Method)
+	}
+}
+
+func mustJSON(t *testing.T, value any) json.RawMessage {
+	t.Helper()
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	return data
+}
+
+func decodeParams(t *testing.T, raw json.RawMessage) map[string]any {
+	t.Helper()
+	var obj map[string]any
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	return obj
+}

--- a/tool/mcp/doc.go
+++ b/tool/mcp/doc.go
@@ -1,0 +1,3 @@
+// Package mcp implements the core Model Context Protocol client primitives
+// used by PetalFlow tool adapters.
+package mcp

--- a/tool/mcp/protocol.go
+++ b/tool/mcp/protocol.go
@@ -1,0 +1,113 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+const (
+	jsonRPCVersion = "2.0"
+)
+
+// Message is a JSON-RPC 2.0 envelope.
+type Message struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      int64           `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+// RPCError is the JSON-RPC error object.
+type RPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+func (e *RPCError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("mcp: rpc error %d: %s", e.Code, e.Message)
+}
+
+// RequestError wraps transport/protocol failures in request flow.
+type RequestError struct {
+	Method string
+	Err    error
+}
+
+func (e *RequestError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return fmt.Sprintf("mcp: request %q failed: %v", e.Method, e.Err)
+}
+
+func (e *RequestError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+// ClientInfo identifies PetalFlow when opening an MCP session.
+type ClientInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+// ServerInfo describes the connected MCP server.
+type ServerInfo struct {
+	Name    string `json:"name"`
+	Version string `json:"version,omitempty"`
+}
+
+// InitializeParams is sent in the MCP initialize request.
+type InitializeParams struct {
+	ProtocolVersion string         `json:"protocolVersion"`
+	Capabilities    map[string]any `json:"capabilities,omitempty"`
+	ClientInfo      ClientInfo     `json:"clientInfo"`
+}
+
+// InitializeResult is returned by the MCP initialize request.
+type InitializeResult struct {
+	ProtocolVersion string         `json:"protocolVersion"`
+	Capabilities    map[string]any `json:"capabilities,omitempty"`
+	ServerInfo      ServerInfo     `json:"serverInfo"`
+}
+
+// Tool describes one discovered MCP tool from tools/list.
+type Tool struct {
+	Name        string         `json:"name"`
+	Description string         `json:"description,omitempty"`
+	InputSchema map[string]any `json:"inputSchema,omitempty"`
+}
+
+// ToolsListResult is returned by the MCP tools/list request.
+type ToolsListResult struct {
+	Tools []Tool `json:"tools"`
+}
+
+// ToolsCallParams is sent in the MCP tools/call request.
+type ToolsCallParams struct {
+	Name      string         `json:"name"`
+	Arguments map[string]any `json:"arguments,omitempty"`
+}
+
+// ContentBlock is an MCP content item returned by tools/call.
+type ContentBlock struct {
+	Type     string `json:"type"`
+	Text     string `json:"text,omitempty"`
+	Data     string `json:"data,omitempty"`
+	MimeType string `json:"mimeType,omitempty"`
+}
+
+// ToolsCallResult is returned by the MCP tools/call request.
+type ToolsCallResult struct {
+	Content           []ContentBlock `json:"content,omitempty"`
+	StructuredContent map[string]any `json:"structuredContent,omitempty"`
+	IsError           bool           `json:"isError,omitempty"`
+}


### PR DESCRIPTION
## Summary
- add new `tool/mcp` package with MCP protocol models and JSON-RPC message envelopes
- implement MCP client core with support for:
  - `initialize` negotiation + `notifications/initialized`
  - `tools/list`
  - `tools/call`
  - `close`
- add transport abstraction so stdio/SSE transport implementations can be added in follow-up tasks
- add mocked protocol tests covering request flow, idempotent initialize behavior, rpc error propagation, and close behavior

## Validation
- `go test ./tool/...`

Closes #36
