### PR TITLE
[codex] enforce registry-aware graph validation

### DIFF
--- a/cli/compile.go
+++ b/cli/compile.go
@@ -11,6 +11,7 @@ import (
 	"github.com/petal-labs/petalflow/agent"
 	"github.com/petal-labs/petalflow/graph"
 	"github.com/petal-labs/petalflow/loader"
+	"github.com/petal-labs/petalflow/registry"
 )
 
 // NewCompileCmd creates the "compile" subcommand.
@@ -92,7 +93,7 @@ func runCompile(cmd *cobra.Command, args []string) error {
 	}
 
 	// Step 7: Graph validation on compiled output
-	graphDiags := gd.Validate()
+	graphDiags := gd.ValidateWithRegistry(registry.Global())
 	if graph.HasErrors(graphDiags) {
 		printDiagnosticsText(stderr, graph.Errors(graphDiags))
 		return exitError(exitValidation, "compiled graph validation failed with %d error(s)", len(graph.Errors(graphDiags)))

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/petal-labs/petalflow/agent"
 	"github.com/petal-labs/petalflow/graph"
 	"github.com/petal-labs/petalflow/loader"
+	"github.com/petal-labs/petalflow/registry"
 )
 
 // NewValidateCmd creates the "validate" subcommand.
@@ -112,7 +113,7 @@ func validateAgentWorkflow(data []byte, filePath string) []graph.Diagnostic {
 				Message:  fmt.Sprintf("Compilation failed: %v", err),
 			})
 		} else {
-			graphDiags := gd.Validate()
+			graphDiags := gd.ValidateWithRegistry(registry.Global())
 			diags = append(diags, graphDiags...)
 		}
 	}
@@ -140,7 +141,7 @@ func validateGraphIR(data []byte, filePath string) []graph.Diagnostic {
 		}}
 	}
 
-	return gd.Validate()
+	return gd.ValidateWithRegistry(registry.Global())
 }
 
 // printValidateDiagnostics writes diagnostics to the writer in the requested

--- a/loader/load.go
+++ b/loader/load.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/petal-labs/petalflow/agent"
 	"github.com/petal-labs/petalflow/graph"
+	"github.com/petal-labs/petalflow/registry"
 )
 
 // LoadWorkflow is the unified entry point that loads a workflow file,
@@ -93,7 +94,7 @@ func loadGraphDefinition(data []byte, path string) (*graph.GraphDefinition, erro
 	}
 
 	// Validate
-	diags := gd.Validate()
+	diags := gd.ValidateWithRegistry(registry.Global())
 	if graph.HasErrors(diags) {
 		return nil, &DiagnosticError{Diagnostics: diags}
 	}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -88,7 +88,7 @@ func (s *Server) handleCreateAgentWorkflow(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	gdDiags := gd.Validate()
+	gdDiags := gd.ValidateWithRegistry(registry.Global())
 	if graph.HasErrors(gdDiags) {
 		details := diagMessages(gdDiags)
 		writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "compiled graph validation failed", details...)
@@ -141,7 +141,7 @@ func (s *Server) handleCreateGraphWorkflow(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	diags := gd.Validate()
+	diags := gd.ValidateWithRegistry(registry.Global())
 	if graph.HasErrors(diags) {
 		details := diagMessages(diags)
 		writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "graph validation failed", details...)
@@ -229,7 +229,7 @@ func (s *Server) handleUpdateWorkflow(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "PARSE_ERROR", err.Error())
 			return
 		}
-		diags := gd.Validate()
+		diags := gd.ValidateWithRegistry(registry.Global())
 		if graph.HasErrors(diags) {
 			details := diagMessages(diags)
 			writeError(w, http.StatusUnprocessableEntity, "VALIDATION_ERROR", "graph validation failed", details...)


### PR DESCRIPTION
## Summary
Graph validation was not consistently registry-aware across compile, validate, load, and server paths. As a result, some graph definitions with unknown node types or invalid handles could pass one path and fail later during hydration/runtime.

## User Impact
Users could see delayed failures after deployment or at execution time rather than receiving deterministic validation errors up front. This undermines 1.0 reliability and makes debugging wiring issues harder.

## Root Cause
Validation primarily relied on structural checks without enforcing registry-backed node-type compatibility in all entry points. There was no single wired path that enforced registry constraints everywhere workflows are loaded/compiled/run.

## Fix
This PR adds and wires registry-aware validation consistently:

- Added `GraphDefinition.ValidateWithRegistry(reg *registry.Registry)` in `graph/definition.go`.
- Enforced:
  - GR-003 unknown node type errors.
  - GR-006 invalid source handle errors for static-output node types.
  - GR-008 disallowing `function_call` tools as standalone node types.
- Wired registry-aware validation through:
  - `loader/load.go`
  - `cli/validate.go`
  - `cli/compile.go`
  - `server/handlers.go`
- Added test coverage for GR-003/GR-006/GR-008 in `graph/definition_test.go`.

## Validation
- `go test ./...` (passes)

## Scope
This PR is scoped to validation behavior and wiring consistency, not runtime hydration changes.
