### PR TITLE
fix: execute standalone tool presteps and add Iris integration coverage

### DIFF
--- a/agent/testdata/hitl_review.golden.json
+++ b/agent/testdata/hitl_review.golden.json
@@ -35,5 +35,5 @@
       "targetHandle": "input"
     }
   ],
-  "entry": "draft__drafter__hitl"
+  "entry": "draft__drafter"
 }

--- a/hydrate/llmfactory_test.go
+++ b/hydrate/llmfactory_test.go
@@ -546,7 +546,13 @@ func TestNewLiveNodeFactory_ToolNodeExplicitType(t *testing.T) {
 		ID:   "search",
 		Type: "tool",
 		Config: map[string]any{
-			"tool_name":  "web_search",
+			"tool_name": "web_search",
+			"args_template": map[string]any{
+				"query": "input.query",
+			},
+			"static_args": map[string]any{
+				"limit": float64(5),
+			},
 			"output_key": "results",
 			"timeout":    float64(2),
 		},
@@ -567,6 +573,12 @@ func TestNewLiveNodeFactory_ToolNodeExplicitType(t *testing.T) {
 	}
 	if cfg.OutputKey != "results" {
 		t.Fatalf("OutputKey = %q, want %q", cfg.OutputKey, "results")
+	}
+	if cfg.ArgsTemplate["query"] != "input.query" {
+		t.Fatalf("ArgsTemplate[query] = %q, want %q", cfg.ArgsTemplate["query"], "input.query")
+	}
+	if limit, ok := cfg.StaticArgs["limit"].(float64); !ok || limit != 5 {
+		t.Fatalf("StaticArgs[limit] = %v, want 5", cfg.StaticArgs["limit"])
 	}
 	if cfg.Timeout != 2*time.Second {
 		t.Fatalf("Timeout = %s, want 2s", cfg.Timeout)
@@ -824,12 +836,12 @@ func TestNewLiveNodeFactory_GuardianNode(t *testing.T) {
 		ID:   "guardian",
 		Type: "guardian",
 		Config: map[string]any{
-			"input_var":              "payload",
-			"on_fail":                "redirect",
-			"fail_message":           "validation failed",
-			"redirect_node_id":       "fallback",
-			"result_var":             "guardian_result",
-			"stop_on_first_failure":  true,
+			"input_var":             "payload",
+			"on_fail":               "redirect",
+			"fail_message":          "validation failed",
+			"redirect_node_id":      "fallback",
+			"result_var":            "guardian_result",
+			"stop_on_first_failure": true,
 			"checks": []any{
 				map[string]any{
 					"name":            "required",

--- a/tests/integration/iris_provider_test.go
+++ b/tests/integration/iris_provider_test.go
@@ -1,0 +1,79 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	iriscore "github.com/petal-labs/iris/core"
+	"github.com/petal-labs/iris/providers/anthropic"
+	"github.com/petal-labs/iris/providers/openai"
+)
+
+func TestIrisProvider_OpenAI_Chat(t *testing.T) {
+	skipIfNoAPIKey(t)
+
+	provider := openai.New(getAPIKey(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := provider.Chat(ctx, &iriscore.ChatRequest{
+		Model: openai.ModelGPT4oMini,
+		Messages: []iriscore.Message{
+			{Role: iriscore.RoleUser, Content: "Reply with one short greeting."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("provider.Chat: %v", err)
+	}
+
+	if resp == nil {
+		t.Fatal("provider.Chat returned nil response")
+	}
+	if resp.Output == "" {
+		t.Fatal("expected non-empty output")
+	}
+	if resp.Usage.TotalTokens == 0 {
+		t.Fatal("expected non-zero token usage")
+	}
+
+	t.Logf("OpenAI chat output: %s", resp.Output)
+}
+
+func TestIrisProvider_Anthropic_ChatOptional(t *testing.T) {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		t.Skip("ANTHROPIC_API_KEY not set, skipping optional Anthropic integration test")
+	}
+
+	provider := anthropic.New(apiKey)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := provider.Chat(ctx, &iriscore.ChatRequest{
+		Model: anthropic.ModelClaudeHaiku45,
+		Messages: []iriscore.Message{
+			{Role: iriscore.RoleUser, Content: "Reply with one short greeting."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("provider.Chat: %v", err)
+	}
+
+	if resp == nil {
+		t.Fatal("provider.Chat returned nil response")
+	}
+	if resp.Output == "" {
+		t.Fatal("expected non-empty output")
+	}
+	if resp.Usage.TotalTokens == 0 {
+		t.Fatal("expected non-zero token usage")
+	}
+
+	t.Logf("Anthropic chat output: %s", resp.Output)
+}

--- a/tests/integration/standalone_tool_test.go
+++ b/tests/integration/standalone_tool_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/petalflow/agent"
+	"github.com/petal-labs/petalflow/core"
+	"github.com/petal-labs/petalflow/hydrate"
+	"github.com/petal-labs/petalflow/registry"
+	"github.com/petal-labs/petalflow/runtime"
+)
+
+type staticLLMClient struct{}
+
+func (c *staticLLMClient) Complete(_ context.Context, req core.LLMRequest) (core.LLMResponse, error) {
+	return core.LLMResponse{
+		Text:     "ack",
+		Model:    req.Model,
+		Provider: "mock",
+		Usage: core.LLMTokenUsage{
+			InputTokens:  1,
+			OutputTokens: 1,
+			TotalTokens:  2,
+		},
+	}, nil
+}
+
+func TestAgentCompile_StandaloneToolExecution_HTTPFetch(t *testing.T) {
+	registry.Global().Register(registry.NodeTypeDef{
+		Type:     "http_fetch.fetch",
+		Category: "tool",
+		IsTool:   true,
+		ToolMode: "standalone",
+		Ports: registry.PortSchema{
+			Inputs: []registry.PortDef{
+				{Name: "url", Type: "string", Required: true},
+				{Name: "method", Type: "string"},
+			},
+			Outputs: []registry.PortDef{
+				{Name: "status_code", Type: "integer"},
+				{Name: "body", Type: "string"},
+			},
+		},
+	})
+	t.Cleanup(func() {
+		registry.Global().Delete("http_fetch.fetch")
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("tool-ok"))
+	}))
+	defer server.Close()
+
+	wf := &agent.AgentWorkflow{
+		ID:      "standalone_tool_exec",
+		Version: "1.0",
+		Kind:    "agent_workflow",
+		Agents: map[string]agent.Agent{
+			"researcher": {
+				Role:     "Researcher",
+				Goal:     "Collect and summarize",
+				Provider: "mock",
+				Model:    "mock-model",
+				Tools:    []string{"http_fetch.fetch"},
+			},
+		},
+		Tasks: map[string]agent.Task{
+			"fetch": {
+				Description:    "Summarize fetched content",
+				Agent:          "researcher",
+				ExpectedOutput: "Summary",
+			},
+		},
+		Execution: agent.ExecutionConfig{
+			Strategy:  "sequential",
+			TaskOrder: []string{"fetch"},
+		},
+	}
+
+	gd, err := agent.Compile(wf)
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+	if gd.Entry != "fetch__http_fetch.fetch" {
+		t.Fatalf("Entry = %q, want fetch__http_fetch.fetch", gd.Entry)
+	}
+
+	toolRegistry, err := hydrate.BuildActionToolRegistry(context.Background(), nil)
+	if err != nil {
+		t.Fatalf("BuildActionToolRegistry() error = %v", err)
+	}
+
+	providers := hydrate.ProviderMap{
+		"mock": {},
+	}
+	factory := hydrate.NewLiveNodeFactory(providers, func(_ string, _ hydrate.ProviderConfig) (core.LLMClient, error) {
+		return &staticLLMClient{}, nil
+	}, hydrate.WithToolRegistry(toolRegistry))
+
+	execGraph, err := hydrate.HydrateGraph(gd, providers, factory)
+	if err != nil {
+		t.Fatalf("HydrateGraph() error = %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	env := core.NewEnvelope().
+		WithVar("url", server.URL).
+		WithVar("method", "GET")
+
+	result, err := runtime.NewRuntime().Run(ctx, execGraph, env, runtime.DefaultRunOptions())
+	if err != nil {
+		t.Fatalf("runtime.Run() error = %v", err)
+	}
+
+	toolOutputKey := "fetch__http_fetch.fetch_output"
+	rawToolOutput, ok := result.GetVar(toolOutputKey)
+	if !ok {
+		t.Fatalf("expected %q in envelope vars", toolOutputKey)
+	}
+	toolOutput, ok := rawToolOutput.(map[string]any)
+	if !ok {
+		t.Fatalf("%s type = %T, want map[string]any", toolOutputKey, rawToolOutput)
+	}
+
+	statusCode, ok := toolOutput["status_code"].(int)
+	if !ok {
+		t.Fatalf("status_code type = %T, want int", toolOutput["status_code"])
+	}
+	if statusCode != http.StatusOK {
+		t.Fatalf("status_code = %d, want %d", statusCode, http.StatusOK)
+	}
+
+	body, _ := toolOutput["body"].(string)
+	if body != "tool-ok" {
+		t.Fatalf("body = %q, want %q", body, "tool-ok")
+	}
+
+	if _, ok := result.GetVar("fetch__researcher_output"); !ok {
+		t.Fatal("expected downstream LLM node output fetch__researcher_output")
+	}
+}


### PR DESCRIPTION
Summary:
- make standalone tool actions executable as true pre-task steps in compiled agent workflows by tracking task start vs task output nodes
- generate default args_template mappings for standalone action inputs and preserve args_template/static_args through live hydration
- add integration coverage for compiled standalone tool execution using http_fetch.fetch through hydrate/runtime
- add integration coverage for direct Iris providers (OpenAI required, Anthropic optional)
- stabilize JSON-schema integration test parsing to accept markdown-fenced JSON responses

Validation:
- go test ./... -count=1
- go test -tags=integration ./tests/integration/... -count=1 -v
