### PR TITLE
chore: clarify runtime test intent and README testing quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ func main() {
 }
 ```
 
+## Testing
+
+```bash
+# Unit and package tests (no external provider calls)
+go test ./... -count=1
+```
+
+```bash
+# External integration tests (requires OPENAI_API_KEY)
+go test -tags=integration ./tests/integration/... -count=1 -v
+```
+
+Optional integration provider coverage:
+
+```bash
+# Enables Anthropic provider integration tests
+export ANTHROPIC_API_KEY=...
+```
+
 ## Core Concepts
 
 ### Graph

--- a/runtime_eventing_test.go
+++ b/runtime_eventing_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package petalflow_test
 
 import (
@@ -16,7 +14,7 @@ import (
 	"github.com/petal-labs/petalflow/runtime"
 )
 
-// mockLLMClient is a deterministic LLM client for integration testing.
+// mockLLMClient is a deterministic LLM client for runtime eventing tests.
 type mockLLMClient struct {
 	response string
 }
@@ -34,7 +32,7 @@ func (m *mockLLMClient) Complete(_ context.Context, req core.LLMRequest) (core.L
 	}, nil
 }
 
-func TestIntegration_EventingPipeline(t *testing.T) {
+func TestRuntimeEventingPipeline(t *testing.T) {
 	// ---------------------------------------------------------------
 	// 1. Build a graph: LLM node -> Tool node
 	// ---------------------------------------------------------------


### PR DESCRIPTION
Summary:
- rename the root runtime eventing test file to clarify it is not an external-provider integration test
- remove the integration build tag from the runtime eventing test so it runs in normal package test runs
- add a concise README Testing section with unit and integration commands, plus optional Anthropic env setup

Validation:
- go test . -count=1
- go test -tags=integration ./tests/integration/... -count=1
- go test ./... -count=1
