### PR TITLE
test: expand Iris provider integration matrix with streaming

### DIFF
--- a/tests/integration/iris_provider_test.go
+++ b/tests/integration/iris_provider_test.go
@@ -77,3 +77,70 @@ func TestIrisProvider_Anthropic_ChatOptional(t *testing.T) {
 
 	t.Logf("Anthropic chat output: %s", resp.Output)
 }
+
+func TestIrisProvider_OpenAI_Stream(t *testing.T) {
+	skipIfNoAPIKey(t)
+
+	provider := openai.New(getAPIKey(t))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	stream, err := provider.StreamChat(ctx, &iriscore.ChatRequest{
+		Model: openai.ModelGPT4oMini,
+		Messages: []iriscore.Message{
+			{Role: iriscore.RoleUser, Content: "Reply with one short greeting."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("provider.StreamChat: %v", err)
+	}
+
+	resp, err := iriscore.DrainStream(ctx, stream)
+	if err != nil {
+		t.Fatalf("DrainStream: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("DrainStream returned nil response")
+	}
+	if resp.Output == "" {
+		t.Fatal("expected non-empty streaming output")
+	}
+
+	t.Logf("OpenAI stream output: %s", resp.Output)
+}
+
+func TestIrisProvider_Anthropic_StreamOptional(t *testing.T) {
+	apiKey := os.Getenv("ANTHROPIC_API_KEY")
+	if apiKey == "" {
+		t.Skip("ANTHROPIC_API_KEY not set, skipping optional Anthropic integration test")
+	}
+
+	provider := anthropic.New(apiKey)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	stream, err := provider.StreamChat(ctx, &iriscore.ChatRequest{
+		Model: anthropic.ModelClaudeHaiku45,
+		Messages: []iriscore.Message{
+			{Role: iriscore.RoleUser, Content: "Reply with one short greeting."},
+		},
+	})
+	if err != nil {
+		t.Fatalf("provider.StreamChat: %v", err)
+	}
+
+	resp, err := iriscore.DrainStream(ctx, stream)
+	if err != nil {
+		t.Fatalf("DrainStream: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("DrainStream returned nil response")
+	}
+	if resp.Output == "" {
+		t.Fatal("expected non-empty streaming output")
+	}
+
+	t.Logf("Anthropic stream output: %s", resp.Output)
+}


### PR DESCRIPTION
Summary:
- add OpenAI streaming integration test via Iris provider StreamChat + DrainStream
- add Anthropic optional streaming integration test via Iris provider StreamChat + DrainStream
- retain existing non-streaming matrix tests for OpenAI (required) and Anthropic (optional)

Validation:
- go test -tags=integration ./tests/integration/... -run 'TestIrisProvider_OpenAI_Chat|TestIrisProvider_OpenAI_Stream|TestIrisProvider_Anthropic_ChatOptional|TestIrisProvider_Anthropic_StreamOptional' -count=1 -v
- go test ./... -count=1
