### PR TITLE
refactor: reduce MCP overlay merge complexity

### DIFF
--- a/tool/mcp_overlay_merge.go
+++ b/tool/mcp_overlay_merge.go
@@ -12,53 +12,89 @@ func MergeMCPOverlay(base Manifest, overlay MCPOverlay) (Manifest, []Diagnostic,
 	merged := cloneManifest(base)
 	diags := ValidateMCPOverlay(overlay)
 	if hasValidationErrors(diags) {
-		return merged, diags, &RegistrationValidationError{
-			Code:    RegistrationValidationFailedCode,
-			Message: "Tool registration failed validation",
-			Details: diags,
-		}
+		return merged, diags, newOverlayValidationError(diags)
 	}
 
+	ensureActionMCPToolNames(&merged)
+	diags = append(diags, applyGroupActions(&merged, overlay)...)
+	applyDescriptionOverrides(&merged, overlay)
+	applyInputOverrides(&merged, overlay)
+	applyOutputSchemas(&merged, overlay)
+	applyActionModes(&merged, overlay)
+	applyConfigOverrides(&merged, overlay)
+	applyMetadataOverrides(&merged, overlay)
+	applyHealthOverrides(&merged, overlay)
+
+	slices.SortFunc(diags, func(a, b Diagnostic) int {
+		if cmp := strings.Compare(a.Field, b.Field); cmp != 0 {
+			return cmp
+		}
+		return strings.Compare(a.Code, b.Code)
+	})
+	if hasValidationErrors(diags) {
+		return merged, diags, newOverlayValidationError(diags)
+	}
+	return merged, diags, nil
+}
+
+func newOverlayValidationError(diags []Diagnostic) error {
+	return &RegistrationValidationError{
+		Code:    RegistrationValidationFailedCode,
+		Message: "Tool registration failed validation",
+		Details: diags,
+	}
+}
+
+func ensureActionMCPToolNames(merged *Manifest) {
 	for actionName, action := range merged.Actions {
-		if strings.TrimSpace(action.MCPToolName) == "" {
-			action.MCPToolName = actionName
-			merged.Actions[actionName] = action
+		if strings.TrimSpace(action.MCPToolName) != "" {
+			continue
 		}
+		action.MCPToolName = actionName
+		merged.Actions[actionName] = action
+	}
+}
+
+func applyGroupActions(merged *Manifest, overlay MCPOverlay) []Diagnostic {
+	if len(overlay.GroupActions) == 0 {
+		return nil
 	}
 
-	if len(overlay.GroupActions) > 0 {
-		grouped := make(map[string]ActionSpec, len(merged.Actions))
-		for name, action := range merged.Actions {
-			grouped[name] = action
-		}
-
-		keys := make([]string, 0, len(overlay.GroupActions))
-		for key := range overlay.GroupActions {
-			keys = append(keys, key)
-		}
-		slices.Sort(keys)
-
-		for _, alias := range keys {
-			target := overlay.GroupActions[alias]
-			sourceAction, ok := merged.Actions[target]
-			if !ok {
-				diags = append(diags, Diagnostic{
-					Field:    "group_actions." + alias,
-					Code:     "UNKNOWN_ACTION",
-					Severity: SeverityError,
-					Message:  fmt.Sprintf("MCP tool %q was not discovered", target),
-				})
-				continue
-			}
-			sourceAction.MCPToolName = target
-			grouped[alias] = sourceAction
-			if alias != target {
-				delete(grouped, target)
-			}
-		}
-		merged.Actions = grouped
+	diags := make([]Diagnostic, 0)
+	grouped := make(map[string]ActionSpec, len(merged.Actions))
+	for name, action := range merged.Actions {
+		grouped[name] = action
 	}
 
+	keys := make([]string, 0, len(overlay.GroupActions))
+	for key := range overlay.GroupActions {
+		keys = append(keys, key)
+	}
+	slices.Sort(keys)
+
+	for _, alias := range keys {
+		target := overlay.GroupActions[alias]
+		sourceAction, ok := merged.Actions[target]
+		if !ok {
+			diags = append(diags, Diagnostic{
+				Field:    "group_actions." + alias,
+				Code:     "UNKNOWN_ACTION",
+				Severity: SeverityError,
+				Message:  fmt.Sprintf("MCP tool %q was not discovered", target),
+			})
+			continue
+		}
+		sourceAction.MCPToolName = target
+		grouped[alias] = sourceAction
+		if alias != target {
+			delete(grouped, target)
+		}
+	}
+	merged.Actions = grouped
+	return diags
+}
+
+func applyDescriptionOverrides(merged *Manifest, overlay MCPOverlay) {
 	for action, override := range overlay.DescriptionOverrides {
 		spec, ok := merged.Actions[action]
 		if !ok {
@@ -67,7 +103,9 @@ func MergeMCPOverlay(base Manifest, overlay MCPOverlay) (Manifest, []Diagnostic,
 		spec.Description = override
 		merged.Actions[action] = spec
 	}
+}
 
+func applyInputOverrides(merged *Manifest, overlay MCPOverlay) {
 	for action, inputOverride := range overlay.InputOverrides {
 		spec, ok := merged.Actions[action]
 		if !ok {
@@ -81,7 +119,9 @@ func MergeMCPOverlay(base Manifest, overlay MCPOverlay) (Manifest, []Diagnostic,
 		}
 		merged.Actions[action] = spec
 	}
+}
 
+func applyOutputSchemas(merged *Manifest, overlay MCPOverlay) {
 	for action, outputSchema := range overlay.OutputSchemas {
 		spec, ok := merged.Actions[action]
 		if !ok {
@@ -90,7 +130,9 @@ func MergeMCPOverlay(base Manifest, overlay MCPOverlay) (Manifest, []Diagnostic,
 		spec.Outputs = cloneFieldMap(outputSchema)
 		merged.Actions[action] = spec
 	}
+}
 
+func applyActionModes(merged *Manifest, overlay MCPOverlay) {
 	for action, mode := range overlay.ActionModes {
 		spec, ok := merged.Actions[action]
 		if !ok {
@@ -106,14 +148,18 @@ func MergeMCPOverlay(base Manifest, overlay MCPOverlay) (Manifest, []Diagnostic,
 		}
 		merged.Actions[action] = spec
 	}
+}
 
+func applyConfigOverrides(merged *Manifest, overlay MCPOverlay) {
 	if merged.Config == nil {
 		merged.Config = map[string]FieldSpec{}
 	}
 	for key, spec := range overlay.Config {
 		merged.Config[key] = spec.FieldSpec
 	}
+}
 
+func applyMetadataOverrides(merged *Manifest, overlay MCPOverlay) {
 	if strings.TrimSpace(overlay.Metadata.Author) != "" {
 		merged.Tool.Author = overlay.Metadata.Author
 	}
@@ -126,42 +172,30 @@ func MergeMCPOverlay(base Manifest, overlay MCPOverlay) (Manifest, []Diagnostic,
 	if len(overlay.Metadata.Tags) > 0 {
 		merged.Tool.Tags = slices.Clone(overlay.Metadata.Tags)
 	}
+}
 
-	if strings.TrimSpace(overlay.Health.Strategy) != "" || strings.TrimSpace(overlay.Health.Endpoint) != "" {
-		if merged.Health == nil {
-			merged.Health = &HealthConfig{}
-		}
-		if strings.TrimSpace(overlay.Health.Endpoint) != "" {
-			merged.Health.Endpoint = overlay.Health.Endpoint
-		}
-		if strings.TrimSpace(overlay.Health.Method) != "" {
-			merged.Health.Method = overlay.Health.Method
-		}
-		if overlay.Health.IntervalSeconds > 0 {
-			merged.Health.IntervalSeconds = overlay.Health.IntervalSeconds
-		}
-		if overlay.Health.TimeoutMS > 0 {
-			merged.Health.TimeoutMS = overlay.Health.TimeoutMS
-		}
-		if overlay.Health.UnhealthyThreshold > 0 {
-			merged.Health.UnhealthyThreshold = overlay.Health.UnhealthyThreshold
-		}
+func applyHealthOverrides(merged *Manifest, overlay MCPOverlay) {
+	if strings.TrimSpace(overlay.Health.Strategy) == "" && strings.TrimSpace(overlay.Health.Endpoint) == "" {
+		return
 	}
-
-	slices.SortFunc(diags, func(a, b Diagnostic) int {
-		if cmp := strings.Compare(a.Field, b.Field); cmp != 0 {
-			return cmp
-		}
-		return strings.Compare(a.Code, b.Code)
-	})
-	if hasValidationErrors(diags) {
-		return merged, diags, &RegistrationValidationError{
-			Code:    RegistrationValidationFailedCode,
-			Message: "Tool registration failed validation",
-			Details: diags,
-		}
+	if merged.Health == nil {
+		merged.Health = &HealthConfig{}
 	}
-	return merged, diags, nil
+	if strings.TrimSpace(overlay.Health.Endpoint) != "" {
+		merged.Health.Endpoint = overlay.Health.Endpoint
+	}
+	if strings.TrimSpace(overlay.Health.Method) != "" {
+		merged.Health.Method = overlay.Health.Method
+	}
+	if overlay.Health.IntervalSeconds > 0 {
+		merged.Health.IntervalSeconds = overlay.Health.IntervalSeconds
+	}
+	if overlay.Health.TimeoutMS > 0 {
+		merged.Health.TimeoutMS = overlay.Health.TimeoutMS
+	}
+	if overlay.Health.UnhealthyThreshold > 0 {
+		merged.Health.UnhealthyThreshold = overlay.Health.UnhealthyThreshold
+	}
 }
 
 func cloneManifest(in Manifest) Manifest {


### PR DESCRIPTION
## Summary
- reduce complexity in `MergeMCPOverlay` by splitting the merge pipeline into focused helper functions
- keep merge semantics intact (validation, grouping, overrides, diagnostics sorting, and failure behavior)
- add targeted tests for:
  - unknown grouped-action mappings returning validation diagnostics/errors
  - metadata/config/health overrides and MCP tool-name fallback behavior

## Why
This addresses another complexity hotspot in the 1.0 hardening backlog while improving maintainability and preserving behavior.

## Testing
- go test ./tool -count=1
- go test ./... -count=1
