### PR TITLE
Resolve daemon hydration wiring for human/map/cache node types

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,9 +116,64 @@ MCP overlays: [`docs/mcp-overlay.md`](./docs/mcp-overlay.md)
 | `rule_router`, `filter`, `transform`, `gate`, `guardian`, `sink` | Yes | Yes | Executable from Graph IR config |
 | `merge`, `conditional`, `noop`, `tool` | Yes | Yes | `tool` requires valid `config.tool_name` and tool registry entry |
 | `tool_name.action_name` | Dynamic | Yes | Compiled from agent tool actions and resolved from tool registry |
-| `human` | Yes | CLI: Yes, Server: Depends | Requires a `HumanHandler`; CLI wires one, server integrations must provide one |
-| `map`, `cache` | Yes | Partial | Require runtime bindings not encodable directly in Graph IR config |
+| `human` | Yes | Yes | Daemon uses `options.human.mode` (`strict`, `auto_approve`, `auto_reject`) to wire a handler at run time |
+| `map`, `cache` | Yes | Yes | Require JSON binding config: `map.config.mapper_binding` and `cache.config.wrapped_binding` |
 | `func` | Yes | Explicit no-op in Graph IR | Custom Go callbacks must be wired in SDK code, not serialized config |
+
+### Daemon Run Bindings (human/map/cache)
+
+Daemon workflow runs accept optional human handler mode under `options.human`:
+
+```json
+{
+  "input": {"topic": "release"},
+  "options": {
+    "timeout": "30s",
+    "human": {
+      "mode": "auto_approve"
+    }
+  }
+}
+```
+
+`map` and `cache` bindings are encoded in graph node config via embedded node definitions:
+
+```json
+{
+  "id": "map_items",
+  "type": "map",
+  "config": {
+    "input_var": "items",
+    "output_var": "mapped",
+    "mapper_binding": {
+      "type": "transform",
+      "config": {
+        "transform": "template",
+        "template": "item={{.item.name}}",
+        "output_var": "label"
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "id": "cache_step",
+  "type": "cache",
+  "config": {
+    "output_var": "cache_meta",
+    "wrapped_binding": {
+      "type": "transform",
+      "config": {
+        "transform": "template",
+        "template": "cached",
+        "output_var": "cache_payload"
+      }
+    }
+  }
+}
+```
 
 ## SDK Quick Start
 

--- a/docs/daemon-api.md
+++ b/docs/daemon-api.md
@@ -52,6 +52,71 @@ Example registration:
 }
 ```
 
+## Workflow Endpoints
+
+| Method | Path | Description |
+| --- | --- | --- |
+| `POST` | `/api/workflows/agent` | Create workflow from Agent/Task schema |
+| `POST` | `/api/workflows/graph` | Create workflow from Graph IR schema |
+| `GET` | `/api/workflows` | List workflows |
+| `GET` | `/api/workflows/{id}` | Get workflow |
+| `PUT` | `/api/workflows/{id}` | Update workflow source and recompile |
+| `DELETE` | `/api/workflows/{id}` | Delete workflow |
+| `POST` | `/api/workflows/{id}/run` | Execute workflow |
+| `GET` | `/api/runs/{run_id}/events` | Fetch persisted run events |
+
+## Workflow Run Bindings
+
+`POST /api/workflows/{id}/run` accepts:
+
+- `input` (`object`): initial envelope variables.
+- `options.timeout` (`duration`): run timeout (default `5m`).
+- `options.stream` (`bool`): stream run events via SSE.
+- `options.human` (`object`): runtime human handler mode.
+
+`options.human.mode` values:
+
+- `strict` (default): hydrate succeeds, but human node requests fail at runtime with a clear configuration error.
+- `auto_approve`: injects an auto-approve handler for all human node requests.
+- `auto_reject`: injects an auto-reject handler for all human node requests.
+
+Optional `options.human` fields for auto modes:
+
+- `choice` (string)
+- `notes` (string)
+- `responded_by` (string)
+- `delay` (duration)
+
+Example run request:
+
+```json
+{
+  "input": {
+    "topic": "issue-113"
+  },
+  "options": {
+    "timeout": "30s",
+    "human": {
+      "mode": "auto_approve",
+      "responded_by": "daemon-e2e"
+    }
+  }
+}
+```
+
+### `map` and `cache` Node Binding Config
+
+`map` and `cache` execute via embedded node bindings in `config`:
+
+- `map.config.mapper_binding` (or alias `mapper_node`)
+- `cache.config.wrapped_binding` (or alias `wrapped_node`)
+
+Both bindings are object node definitions with:
+
+- `type` (required)
+- `id` (optional; auto-generated if omitted)
+- `config` (optional object)
+
 ## Security and Error Semantics
 
 - Sensitive tool config values are always masked in API responses (`**********`).

--- a/server/human_options_test.go
+++ b/server/human_options_test.go
@@ -1,0 +1,171 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/petalflow/core"
+	"github.com/petal-labs/petalflow/hydrate"
+	"github.com/petal-labs/petalflow/nodes"
+)
+
+func TestBuildRunHumanHandler_DefaultStrict(t *testing.T) {
+	handler, err := buildRunHumanHandler(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = handler.Request(context.Background(), &nodes.HumanRequest{
+		ID:   "req-1",
+		Type: nodes.HumanRequestApproval,
+	})
+	if err == nil {
+		t.Fatal("expected strict handler to fail")
+	}
+	if !strings.Contains(err.Error(), "options.human.mode") {
+		t.Fatalf("strict handler error = %q, want guidance for options.human.mode", err.Error())
+	}
+}
+
+func TestBuildRunHumanHandler_AutoApprove(t *testing.T) {
+	handler, err := buildRunHumanHandler(&RunReqHumanOptions{
+		Mode:        "auto_approve",
+		Choice:      "approve",
+		Notes:       "looks good",
+		RespondedBy: "ci",
+		Delay:       "1ms",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resp, err := handler.Request(context.Background(), &nodes.HumanRequest{
+		ID:   "req-1",
+		Type: nodes.HumanRequestApproval,
+	})
+	if err != nil {
+		t.Fatalf("unexpected handler error: %v", err)
+	}
+	if !resp.Approved {
+		t.Fatal("expected auto approve response to be approved")
+	}
+	if resp.RespondedBy != "ci" {
+		t.Fatalf("responded_by = %q, want %q", resp.RespondedBy, "ci")
+	}
+	if resp.Notes != "looks good" {
+		t.Fatalf("notes = %q, want %q", resp.Notes, "looks good")
+	}
+}
+
+func TestBuildRunHumanHandler_AutoReject(t *testing.T) {
+	handler, err := buildRunHumanHandler(&RunReqHumanOptions{Mode: "auto_reject"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	resp, err := handler.Request(context.Background(), &nodes.HumanRequest{
+		ID:   "req-1",
+		Type: nodes.HumanRequestApproval,
+	})
+	if err != nil {
+		t.Fatalf("unexpected handler error: %v", err)
+	}
+	if resp.Approved {
+		t.Fatal("expected auto reject response to be rejected")
+	}
+}
+
+func TestBuildRunHumanHandler_InvalidOptions(t *testing.T) {
+	_, err := buildRunHumanHandler(&RunReqHumanOptions{Mode: "invalid"})
+	if err == nil || !strings.Contains(err.Error(), "options.human.mode") {
+		t.Fatalf("invalid mode error = %v", err)
+	}
+
+	_, err = buildRunHumanHandler(&RunReqHumanOptions{Mode: "auto_approve", Delay: "not-a-duration"})
+	if err == nil || !strings.Contains(err.Error(), "options.human.delay") {
+		t.Fatalf("invalid delay error = %v", err)
+	}
+}
+
+func TestRunWorkflow_InvalidHumanOptions(t *testing.T) {
+	srv := NewServer(ServerConfig{
+		Store:     NewMemoryStore(),
+		Providers: hydrate.ProviderMap{},
+		ClientFactory: func(name string, cfg hydrate.ProviderConfig) (core.LLMClient, error) {
+			return nil, nil
+		},
+	})
+	handler := srv.Handler()
+
+	createBody := mustJSON(t, map[string]any{
+		"id":      "bad-human-options",
+		"version": "1.0",
+		"nodes": []map[string]any{
+			{"id": "echo", "type": "func"},
+		},
+		"edges": []map[string]any{},
+		"entry": "echo",
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/workflows/graph", bytes.NewReader(createBody))
+	createW := httptest.NewRecorder()
+	handler.ServeHTTP(createW, createReq)
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create workflow failed: status=%d body=%s", createW.Code, createW.Body.String())
+	}
+
+	runBody := mustJSON(t, RunRequest{
+		Options: RunReqOptions{
+			Timeout: "1s",
+			Human: &RunReqHumanOptions{
+				Mode: "invalid",
+			},
+		},
+	})
+	runReq := httptest.NewRequest(http.MethodPost, "/api/workflows/bad-human-options/run", bytes.NewReader(runBody))
+	runW := httptest.NewRecorder()
+	handler.ServeHTTP(runW, runReq)
+
+	if runW.Code != http.StatusBadRequest {
+		t.Fatalf("run status=%d, want %d body=%s", runW.Code, http.StatusBadRequest, runW.Body.String())
+	}
+
+	var payload struct {
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(runW.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("unmarshal error response: %v", err)
+	}
+	if payload.Error.Code != "INVALID_HUMAN_OPTIONS" {
+		t.Fatalf("error code = %q, want %q", payload.Error.Code, "INVALID_HUMAN_OPTIONS")
+	}
+}
+
+func TestBuildRunHumanHandler_AutoApproveDelay(t *testing.T) {
+	handler, err := buildRunHumanHandler(&RunReqHumanOptions{
+		Mode:  "auto_approve",
+		Delay: "10ms",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	start := time.Now()
+	_, err = handler.Request(context.Background(), &nodes.HumanRequest{
+		ID:   "req-2",
+		Type: nodes.HumanRequestApproval,
+	})
+	if err != nil {
+		t.Fatalf("unexpected handler error: %v", err)
+	}
+	if elapsed := time.Since(start); elapsed < 10*time.Millisecond {
+		t.Fatalf("expected handler delay >=10ms, got %s", elapsed)
+	}
+}


### PR DESCRIPTION
## Summary
- implement live hydration for map and cache by resolving JSON binding configs (`mapper_binding`/`mapper_node`, `wrapped_binding`/`wrapped_node`)
- add daemon run-time human handling options (`options.human.mode`) with `strict` (default), `auto_approve`, and `auto_reject`
- replace hydrate-gap daemon E2E assertions with positive coverage for human/map/cache, including tracing/event assertions
- add unit coverage for binding parsing and human option validation
- document daemon run binding contract in README and daemon API docs

Closes #113

## Testing
- `go test ./hydrate -count=1`
- `go test ./server -count=1`
- `go test ./... -count=1`
