### PR TITLE
[codex] Add UTC cron workflow scheduling

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ petalflow run examples/06_cli_workflow/research.agent.yaml --input '{"topic":"Go
 
 Daemon docs and endpoints: [`docs/daemon-api.md`](./docs/daemon-api.md)
 
+Workflow cron scheduling is available in daemon mode via
+`/api/workflows/{id}/schedules` (UTC-only, standard Unix 5-field cron).
+
 ## Provider Setup
 
 Provider resolution priority is:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/petal-labs/iris v0.11.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/cobra v1.10.2
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/metric v1.40.0

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/otel/metrics.go
+++ b/otel/metrics.go
@@ -96,8 +96,15 @@ func (h *MetricsHandler) handleNodeFailed(e runtime.Event) {
 // handleRunFinished records the workflow run duration.
 func (h *MetricsHandler) handleRunFinished(e runtime.Event) {
 	ctx := context.Background()
-	attrs := metric.WithAttributes(
+	attrList := []attribute.KeyValue{
 		attribute.String("run_id", e.RunID),
-	)
+	}
+	if trigger, ok := e.Payload["trigger"].(string); ok && trigger != "" {
+		attrList = append(attrList, attribute.String("trigger", trigger))
+	}
+	if scheduleID, ok := e.Payload["schedule_id"].(string); ok && scheduleID != "" {
+		attrList = append(attrList, attribute.String("schedule_id", scheduleID))
+	}
+	attrs := metric.WithAttributes(attrList...)
 	h.runDuration.Record(ctx, e.Elapsed.Seconds(), attrs)
 }

--- a/otel/tracing.go
+++ b/otel/tracing.go
@@ -64,6 +64,30 @@ func (h *TracingHandler) handleRunStarted(e runtime.Event) {
 			graphName = s
 		}
 	}
+	trigger := ""
+	if value, ok := e.Payload["trigger"]; ok {
+		if s, ok := value.(string); ok {
+			trigger = s
+		}
+	}
+	scheduleID := ""
+	if value, ok := e.Payload["schedule_id"]; ok {
+		if s, ok := value.(string); ok {
+			scheduleID = s
+		}
+	}
+	workflowID := ""
+	if value, ok := e.Payload["workflow_id"]; ok {
+		if s, ok := value.(string); ok {
+			workflowID = s
+		}
+	}
+	scheduledAt := ""
+	if value, ok := e.Payload["scheduled_at"]; ok {
+		if s, ok := value.(string); ok {
+			scheduledAt = s
+		}
+	}
 
 	spanName := "run:" + e.RunID
 	if graphName != "" {
@@ -79,6 +103,18 @@ func (h *TracingHandler) handleRunStarted(e runtime.Event) {
 
 	if graphName != "" {
 		span.SetAttributes(attribute.String("petalflow.graph", graphName))
+	}
+	if trigger != "" {
+		span.SetAttributes(attribute.String("petalflow.trigger", trigger))
+	}
+	if scheduleID != "" {
+		span.SetAttributes(attribute.String("petalflow.schedule_id", scheduleID))
+	}
+	if workflowID != "" {
+		span.SetAttributes(attribute.String("petalflow.workflow_id", workflowID))
+	}
+	if scheduledAt != "" {
+		span.SetAttributes(attribute.String("petalflow.scheduled_at", scheduledAt))
 	}
 
 	h.mu.Lock()

--- a/server/cron.go
+++ b/server/cron.go
@@ -1,0 +1,43 @@
+package server
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+var standardCronParser = cron.NewParser(
+	cron.Minute |
+		cron.Hour |
+		cron.Dom |
+		cron.Month |
+		cron.Dow,
+)
+
+func nextCronRunUTC(expr string, now time.Time) (time.Time, error) {
+	schedule, err := parseCronExpressionUTC(expr)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return schedule.Next(now.UTC()), nil
+}
+
+func parseCronExpressionUTC(expr string) (cron.Schedule, error) {
+	clean := strings.TrimSpace(expr)
+	if clean == "" {
+		return nil, fmt.Errorf("cron expression is required")
+	}
+
+	upper := strings.ToUpper(clean)
+	if strings.Contains(upper, "CRON_TZ=") || strings.Contains(upper, "TZ=") {
+		return nil, fmt.Errorf("cron expression must be UTC-only (timezone prefixes are not allowed)")
+	}
+
+	schedule, err := standardCronParser.Parse(clean)
+	if err != nil {
+		return nil, fmt.Errorf("invalid cron expression: %w", err)
+	}
+	return schedule, nil
+}

--- a/server/cron_test.go
+++ b/server/cron_test.go
@@ -1,0 +1,30 @@
+package server
+
+import (
+	"testing"
+	"time"
+)
+
+func TestParseCronExpressionUTC_Valid(t *testing.T) {
+	schedule, err := parseCronExpressionUTC("*/5 * * * *")
+	if err != nil {
+		t.Fatalf("parseCronExpressionUTC error: %v", err)
+	}
+
+	next := schedule.Next(time.Date(2026, 2, 20, 10, 2, 0, 0, time.UTC))
+	want := time.Date(2026, 2, 20, 10, 5, 0, 0, time.UTC)
+	if !next.Equal(want) {
+		t.Fatalf("next=%s, want=%s", next.Format(time.RFC3339), want.Format(time.RFC3339))
+	}
+}
+
+func TestParseCronExpressionUTC_RejectsTimezonePrefixes(t *testing.T) {
+	for _, expr := range []string{
+		"CRON_TZ=America/Los_Angeles * * * * *",
+		"TZ=UTC * * * * *",
+	} {
+		if _, err := parseCronExpressionUTC(expr); err == nil {
+			t.Fatalf("parseCronExpressionUTC(%q) expected error", expr)
+		}
+	}
+}

--- a/server/run_service.go
+++ b/server/run_service.go
@@ -1,0 +1,186 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/petal-labs/petalflow/bus"
+	"github.com/petal-labs/petalflow/core"
+	"github.com/petal-labs/petalflow/graph"
+	"github.com/petal-labs/petalflow/hydrate"
+	"github.com/petal-labs/petalflow/runtime"
+)
+
+type runAPIError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (e *runAPIError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return e.Message
+}
+
+type workflowRunPlan struct {
+	execGraph *graph.BasicGraph
+	env       *core.Envelope
+	timeout   time.Duration
+}
+
+type scheduledRunMetadata struct {
+	ScheduleID  string
+	WorkflowID  string
+	ScheduledAt time.Time
+}
+
+func (s *Server) planWorkflowRun(ctx context.Context, workflowID string, req RunRequest) (*workflowRunPlan, error) {
+	rec, ok, err := s.store.Get(ctx, workflowID)
+	if err != nil {
+		return nil, &runAPIError{Status: http.StatusInternalServerError, Code: "STORE_ERROR", Message: err.Error()}
+	}
+	if !ok {
+		return nil, &runAPIError{Status: http.StatusNotFound, Code: "NOT_FOUND", Message: fmt.Sprintf("workflow %q not found", workflowID)}
+	}
+	if rec.Compiled == nil {
+		return nil, &runAPIError{Status: http.StatusBadRequest, Code: "NOT_COMPILED", Message: "workflow has no compiled graph"}
+	}
+
+	timeout := 5 * time.Minute
+	if req.Options.Timeout != "" {
+		d, err := time.ParseDuration(req.Options.Timeout)
+		if err != nil {
+			return nil, &runAPIError{Status: http.StatusBadRequest, Code: "INVALID_TIMEOUT", Message: err.Error()}
+		}
+		timeout = d
+	}
+
+	humanHandler, err := buildRunHumanHandler(req.Options.Human)
+	if err != nil {
+		return nil, &runAPIError{Status: http.StatusBadRequest, Code: "INVALID_HUMAN_OPTIONS", Message: err.Error()}
+	}
+
+	toolRegistry, err := hydrate.BuildActionToolRegistry(ctx, s.toolStore)
+	if err != nil {
+		return nil, &runAPIError{Status: http.StatusInternalServerError, Code: "TOOL_REGISTRY_ERROR", Message: err.Error()}
+	}
+
+	factory := hydrate.NewLiveNodeFactory(s.providers, s.clientFactory,
+		hydrate.WithToolRegistry(toolRegistry),
+		hydrate.WithHumanHandler(humanHandler),
+	)
+	execGraph, err := hydrate.HydrateGraph(rec.Compiled, s.providers, factory)
+	if err != nil {
+		return nil, &runAPIError{Status: http.StatusUnprocessableEntity, Code: "HYDRATE_ERROR", Message: err.Error()}
+	}
+
+	return &workflowRunPlan{
+		execGraph: execGraph,
+		env:       EnvelopeFromJSON(req.Input),
+		timeout:   timeout,
+	}, nil
+}
+
+func (s *Server) executeWorkflowRunSync(
+	ctx context.Context,
+	workflowID string,
+	plan *workflowRunPlan,
+	extraDecorator runtime.EventEmitterDecorator,
+) (RunResponse, error) {
+	runCtx, cancel := context.WithTimeout(ctx, plan.timeout)
+	defer cancel()
+
+	rt := runtime.NewRuntime()
+	opts := runtime.DefaultRunOptions()
+	opts.EventEmitterDecorator = combineEmitDecorators(s.emitDecorator, extraDecorator)
+
+	if s.bus != nil {
+		opts.EventBus = s.bus
+	}
+	if s.runtimeEvents != nil {
+		opts.EventHandler = runtime.MultiEventHandler(opts.EventHandler, s.runtimeEvents)
+	}
+
+	if s.eventStore != nil && s.bus != nil {
+		sub := bus.NewStoreSubscriber(s.eventStore, s.logger)
+		opts.EventHandler = runtime.MultiEventHandler(opts.EventHandler, sub.Handle)
+	}
+
+	startedAt := time.Now().UTC()
+	result, err := rt.Run(runCtx, plan.execGraph, plan.env, opts)
+	completedAt := time.Now().UTC()
+
+	if err != nil {
+		if runCtx.Err() == context.DeadlineExceeded {
+			return RunResponse{}, &runAPIError{Status: http.StatusGatewayTimeout, Code: "TIMEOUT", Message: err.Error()}
+		}
+		return RunResponse{}, &runAPIError{Status: http.StatusInternalServerError, Code: "RUNTIME_ERROR", Message: err.Error()}
+	}
+
+	runID := ""
+	if result != nil {
+		runID = result.Trace.RunID
+	}
+
+	return RunResponse{
+		ID:          workflowID,
+		RunID:       runID,
+		Status:      "completed",
+		StartedAt:   startedAt,
+		CompletedAt: completedAt,
+		DurationMs:  completedAt.Sub(startedAt).Milliseconds(),
+		Output:      EnvelopeToJSON(result),
+	}, nil
+}
+
+func (s *Server) runScheduledWorkflow(
+	ctx context.Context,
+	workflowID string,
+	req RunRequest,
+	meta scheduledRunMetadata,
+) (RunResponse, error) {
+	plan, err := s.planWorkflowRun(ctx, workflowID, req)
+	if err != nil {
+		return RunResponse{}, err
+	}
+
+	decorator := scheduleRunMetadataDecorator(meta)
+	return s.executeWorkflowRunSync(ctx, workflowID, plan, decorator)
+}
+
+func combineEmitDecorators(
+	first runtime.EventEmitterDecorator,
+	second runtime.EventEmitterDecorator,
+) runtime.EventEmitterDecorator {
+	switch {
+	case first == nil:
+		return second
+	case second == nil:
+		return first
+	default:
+		return func(emit runtime.EventEmitter) runtime.EventEmitter {
+			return second(first(emit))
+		}
+	}
+}
+
+func scheduleRunMetadataDecorator(meta scheduledRunMetadata) runtime.EventEmitterDecorator {
+	return func(next runtime.EventEmitter) runtime.EventEmitter {
+		return func(e runtime.Event) {
+			if e.Kind == runtime.EventRunStarted || e.Kind == runtime.EventRunFinished {
+				if e.Payload == nil {
+					e.Payload = map[string]any{}
+				}
+				e.Payload["trigger"] = "schedule"
+				e.Payload["schedule_id"] = meta.ScheduleID
+				e.Payload["workflow_id"] = meta.WorkflowID
+				e.Payload["scheduled_at"] = meta.ScheduledAt.UTC().Format(time.RFC3339Nano)
+			}
+			next(e)
+		}
+	}
+}

--- a/server/schedule_handlers.go
+++ b/server/schedule_handlers.go
@@ -1,0 +1,239 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type workflowScheduleRequest struct {
+	Cron    string         `json:"cron,omitempty"`
+	Enabled *bool          `json:"enabled,omitempty"`
+	Input   map[string]any `json:"input,omitempty"`
+	Options *RunReqOptions `json:"options,omitempty"`
+}
+
+func (s *Server) handleListWorkflowSchedules(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	if s.scheduleStore == nil {
+		writeError(w, http.StatusNotImplemented, "NOT_IMPLEMENTED", "workflow schedules are not configured")
+		return
+	}
+	if !s.workflowExists(r.Context(), workflowID, w) {
+		return
+	}
+
+	schedules, err := s.scheduleStore.ListSchedules(r.Context(), workflowID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "STORE_ERROR", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, schedules)
+}
+
+func (s *Server) handleCreateWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	if s.scheduleStore == nil {
+		writeError(w, http.StatusNotImplemented, "NOT_IMPLEMENTED", "workflow schedules are not configured")
+		return
+	}
+	if !s.workflowExists(r.Context(), workflowID, w) {
+		return
+	}
+
+	var req workflowScheduleRequest
+	if err := decodeJSONBody(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "PARSE_ERROR", err.Error())
+		return
+	}
+
+	now := time.Now().UTC()
+	schedule := WorkflowSchedule{
+		ID:         uuid.NewString(),
+		WorkflowID: workflowID,
+		Enabled:    true,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	updated, err := applyScheduleRequest(schedule, req, true, now)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_SCHEDULE", err.Error())
+		return
+	}
+
+	if err := s.scheduleStore.CreateSchedule(r.Context(), updated); err != nil {
+		if errors.Is(err, ErrWorkflowScheduleExists) {
+			writeError(w, http.StatusConflict, "CONFLICT", fmt.Sprintf("schedule %q already exists", updated.ID))
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "STORE_ERROR", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, updated)
+}
+
+func (s *Server) handleGetWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	scheduleID := r.PathValue("schedule_id")
+	if s.scheduleStore == nil {
+		writeError(w, http.StatusNotImplemented, "NOT_IMPLEMENTED", "workflow schedules are not configured")
+		return
+	}
+	if !s.workflowExists(r.Context(), workflowID, w) {
+		return
+	}
+
+	schedule, found, err := s.scheduleStore.GetSchedule(r.Context(), workflowID, scheduleID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "STORE_ERROR", err.Error())
+		return
+	}
+	if !found {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("schedule %q not found", scheduleID))
+		return
+	}
+	writeJSON(w, http.StatusOK, schedule)
+}
+
+func (s *Server) handleUpdateWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	scheduleID := r.PathValue("schedule_id")
+	if s.scheduleStore == nil {
+		writeError(w, http.StatusNotImplemented, "NOT_IMPLEMENTED", "workflow schedules are not configured")
+		return
+	}
+	if !s.workflowExists(r.Context(), workflowID, w) {
+		return
+	}
+
+	existing, found, err := s.scheduleStore.GetSchedule(r.Context(), workflowID, scheduleID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "STORE_ERROR", err.Error())
+		return
+	}
+	if !found {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("schedule %q not found", scheduleID))
+		return
+	}
+
+	var req workflowScheduleRequest
+	if err := decodeJSONBody(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "PARSE_ERROR", err.Error())
+		return
+	}
+
+	now := time.Now().UTC()
+	next, err := applyScheduleRequest(existing, req, false, now)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "INVALID_SCHEDULE", err.Error())
+		return
+	}
+	next.UpdatedAt = now
+
+	if err := s.scheduleStore.UpdateSchedule(r.Context(), next); err != nil {
+		if errors.Is(err, ErrWorkflowScheduleNotFound) {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("schedule %q not found", scheduleID))
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "STORE_ERROR", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, next)
+}
+
+func (s *Server) handleDeleteWorkflowSchedule(w http.ResponseWriter, r *http.Request) {
+	workflowID := r.PathValue("id")
+	scheduleID := r.PathValue("schedule_id")
+	if s.scheduleStore == nil {
+		writeError(w, http.StatusNotImplemented, "NOT_IMPLEMENTED", "workflow schedules are not configured")
+		return
+	}
+	if !s.workflowExists(r.Context(), workflowID, w) {
+		return
+	}
+
+	if err := s.scheduleStore.DeleteSchedule(r.Context(), workflowID, scheduleID); err != nil {
+		if errors.Is(err, ErrWorkflowScheduleNotFound) {
+			writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("schedule %q not found", scheduleID))
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "STORE_ERROR", err.Error())
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) workflowExists(ctx context.Context, workflowID string, w http.ResponseWriter) bool {
+	_, found, err := s.store.Get(ctx, workflowID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "STORE_ERROR", err.Error())
+		return false
+	}
+	if !found {
+		writeError(w, http.StatusNotFound, "NOT_FOUND", fmt.Sprintf("workflow %q not found", workflowID))
+		return false
+	}
+	return true
+}
+
+func applyScheduleRequest(base WorkflowSchedule, req workflowScheduleRequest, creating bool, now time.Time) (WorkflowSchedule, error) {
+	currentCron := base.Cron
+	wasEnabled := base.Enabled
+
+	if cleanCron := strings.TrimSpace(req.Cron); cleanCron != "" {
+		base.Cron = cleanCron
+	}
+	if req.Enabled != nil {
+		base.Enabled = *req.Enabled
+	}
+	if req.Input != nil {
+		base.Input = req.Input
+	}
+	if req.Options != nil {
+		base.Options = *req.Options
+	}
+
+	if strings.TrimSpace(base.Cron) == "" {
+		return WorkflowSchedule{}, fmt.Errorf("cron is required")
+	}
+	if base.Options.Stream {
+		return WorkflowSchedule{}, fmt.Errorf("options.stream is not supported for scheduled runs")
+	}
+	if strings.TrimSpace(base.Options.Timeout) != "" {
+		if _, err := time.ParseDuration(base.Options.Timeout); err != nil {
+			return WorkflowSchedule{}, fmt.Errorf("options.timeout: %w", err)
+		}
+	}
+	if _, err := buildRunHumanHandler(base.Options.Human); err != nil {
+		return WorkflowSchedule{}, err
+	}
+	if _, err := parseCronExpressionUTC(base.Cron); err != nil {
+		return WorkflowSchedule{}, err
+	}
+
+	cronChanged := strings.TrimSpace(currentCron) != "" && currentCron != base.Cron
+	if base.Enabled && (creating || cronChanged || (!wasEnabled && base.Enabled) || base.NextRunAt.IsZero()) {
+		nextRunAt, err := nextCronRunUTC(base.Cron, now.UTC())
+		if err != nil {
+			return WorkflowSchedule{}, err
+		}
+		base.NextRunAt = nextRunAt
+	}
+
+	return base, nil
+}
+
+func decodeJSONBody(r *http.Request, dest any) error {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(dest); err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/schedule_handlers_test.go
+++ b/server/schedule_handlers_test.go
@@ -1,0 +1,137 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestWorkflowScheduleHandlers_CRUD(t *testing.T) {
+	srv := testServer(t)
+	handler := srv.Handler()
+
+	mustCreateWorkflowForScheduleHandlers(t, handler, "schedule-crud")
+
+	createBody := mustJSON(t, workflowScheduleRequest{
+		Cron:  "*/5 * * * *",
+		Input: map[string]any{"topic": "cron"},
+		Options: &RunReqOptions{
+			Timeout: "30s",
+			Human: &RunReqHumanOptions{
+				Mode: "strict",
+			},
+		},
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/api/workflows/schedule-crud/schedules", bytes.NewReader(createBody))
+	createReq.Header.Set("Content-Type", "application/json")
+	createW := httptest.NewRecorder()
+	handler.ServeHTTP(createW, createReq)
+	if createW.Code != http.StatusCreated {
+		t.Fatalf("create schedule status=%d, want %d body=%s", createW.Code, http.StatusCreated, createW.Body.String())
+	}
+
+	var created WorkflowSchedule
+	if err := json.Unmarshal(createW.Body.Bytes(), &created); err != nil {
+		t.Fatalf("unmarshal create response: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatal("created schedule id is empty")
+	}
+	if created.Cron != "*/5 * * * *" {
+		t.Fatalf("created cron=%q, want %q", created.Cron, "*/5 * * * *")
+	}
+	if created.NextRunAt.IsZero() {
+		t.Fatal("created next_run_at is zero")
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/workflows/schedule-crud/schedules", nil)
+	listW := httptest.NewRecorder()
+	handler.ServeHTTP(listW, listReq)
+	if listW.Code != http.StatusOK {
+		t.Fatalf("list schedule status=%d, want %d body=%s", listW.Code, http.StatusOK, listW.Body.String())
+	}
+	var schedules []WorkflowSchedule
+	if err := json.Unmarshal(listW.Body.Bytes(), &schedules); err != nil {
+		t.Fatalf("unmarshal list response: %v", err)
+	}
+	if len(schedules) != 1 {
+		t.Fatalf("list count=%d, want 1", len(schedules))
+	}
+
+	updateBody := mustJSON(t, workflowScheduleRequest{
+		Enabled: boolPtr(false),
+		Cron:    "0 * * * *",
+	})
+	updateReq := httptest.NewRequest(http.MethodPut, "/api/workflows/schedule-crud/schedules/"+created.ID, bytes.NewReader(updateBody))
+	updateReq.Header.Set("Content-Type", "application/json")
+	updateW := httptest.NewRecorder()
+	handler.ServeHTTP(updateW, updateReq)
+	if updateW.Code != http.StatusOK {
+		t.Fatalf("update schedule status=%d, want %d body=%s", updateW.Code, http.StatusOK, updateW.Body.String())
+	}
+
+	var updated WorkflowSchedule
+	if err := json.Unmarshal(updateW.Body.Bytes(), &updated); err != nil {
+		t.Fatalf("unmarshal update response: %v", err)
+	}
+	if updated.Enabled {
+		t.Fatal("updated enabled=true, want false")
+	}
+	if updated.Cron != "0 * * * *" {
+		t.Fatalf("updated cron=%q, want %q", updated.Cron, "0 * * * *")
+	}
+
+	deleteReq := httptest.NewRequest(http.MethodDelete, "/api/workflows/schedule-crud/schedules/"+created.ID, nil)
+	deleteW := httptest.NewRecorder()
+	handler.ServeHTTP(deleteW, deleteReq)
+	if deleteW.Code != http.StatusNoContent {
+		t.Fatalf("delete schedule status=%d, want %d body=%s", deleteW.Code, http.StatusNoContent, deleteW.Body.String())
+	}
+}
+
+func TestWorkflowScheduleHandlers_Validation(t *testing.T) {
+	srv := testServer(t)
+	handler := srv.Handler()
+	mustCreateWorkflowForScheduleHandlers(t, handler, "schedule-validation")
+
+	invalidCronBody := mustJSON(t, workflowScheduleRequest{Cron: "bad cron"})
+	req := httptest.NewRequest(http.MethodPost, "/api/workflows/schedule-validation/schedules", bytes.NewReader(invalidCronBody))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("invalid cron status=%d, want %d body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+
+	streamBody := mustJSON(t, workflowScheduleRequest{
+		Cron: "* * * * *",
+		Options: &RunReqOptions{
+			Stream: true,
+		},
+	})
+	req = httptest.NewRequest(http.MethodPost, "/api/workflows/schedule-validation/schedules", bytes.NewReader(streamBody))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("stream option status=%d, want %d body=%s", w.Code, http.StatusBadRequest, w.Body.String())
+	}
+}
+
+func mustCreateWorkflowForScheduleHandlers(t *testing.T, handler http.Handler, workflowID string) {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/workflows/graph", bytes.NewReader(validGraphJSON(workflowID)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create workflow status=%d, want %d body=%s", w.Code, http.StatusCreated, w.Body.String())
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/server/schedule_store.go
+++ b/server/schedule_store.go
@@ -1,0 +1,49 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrWorkflowScheduleExists   = errors.New("workflow schedule already exists")
+	ErrWorkflowScheduleNotFound = errors.New("workflow schedule not found")
+)
+
+const (
+	ScheduleRunStatusRunning        = "running"
+	ScheduleRunStatusCompleted      = "completed"
+	ScheduleRunStatusFailed         = "failed"
+	ScheduleRunStatusSkippedOverlap = "skipped_overlap"
+)
+
+// WorkflowSchedule represents a persisted cron schedule for a workflow.
+type WorkflowSchedule struct {
+	ID         string         `json:"id"`
+	WorkflowID string         `json:"workflow_id"`
+	Cron       string         `json:"cron"`
+	Enabled    bool           `json:"enabled"`
+	Input      map[string]any `json:"input,omitempty"`
+	Options    RunReqOptions  `json:"options,omitempty"`
+
+	NextRunAt  time.Time  `json:"next_run_at"`
+	LastRunAt  *time.Time `json:"last_run_at,omitempty"`
+	LastRunID  string     `json:"last_run_id,omitempty"`
+	LastStatus string     `json:"last_status,omitempty"`
+	LastError  string     `json:"last_error,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// WorkflowScheduleStore provides CRUD + due scheduling operations.
+type WorkflowScheduleStore interface {
+	ListSchedules(ctx context.Context, workflowID string) ([]WorkflowSchedule, error)
+	GetSchedule(ctx context.Context, workflowID, scheduleID string) (WorkflowSchedule, bool, error)
+	CreateSchedule(ctx context.Context, schedule WorkflowSchedule) error
+	UpdateSchedule(ctx context.Context, schedule WorkflowSchedule) error
+	DeleteSchedule(ctx context.Context, workflowID, scheduleID string) error
+	DeleteSchedulesByWorkflow(ctx context.Context, workflowID string) error
+	ListDueSchedules(ctx context.Context, now time.Time, limit int) ([]WorkflowSchedule, error)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -14,6 +14,7 @@ import (
 // ServerConfig configures a Server instance.
 type ServerConfig struct {
 	Store         WorkflowStore
+	ScheduleStore WorkflowScheduleStore
 	ToolStore     tool.Store
 	Providers     hydrate.ProviderMap
 	ClientFactory hydrate.ClientFactory
@@ -29,6 +30,7 @@ type ServerConfig struct {
 // Server is the PetalFlow HTTP API server.
 type Server struct {
 	store         WorkflowStore
+	scheduleStore WorkflowScheduleStore
 	toolStore     tool.Store
 	providers     hydrate.ProviderMap
 	clientFactory hydrate.ClientFactory
@@ -57,6 +59,7 @@ func NewServer(cfg ServerConfig) *Server {
 	}
 	return &Server{
 		store:         cfg.Store,
+		scheduleStore: cfg.ScheduleStore,
 		toolStore:     cfg.ToolStore,
 		providers:     cfg.Providers,
 		clientFactory: cfg.ClientFactory,
@@ -95,6 +98,11 @@ func (s *Server) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("PUT /api/workflows/{id}", s.handleUpdateWorkflow)
 	mux.HandleFunc("DELETE /api/workflows/{id}", s.handleDeleteWorkflow)
 	mux.HandleFunc("POST /api/workflows/{id}/run", s.handleRunWorkflow)
+	mux.HandleFunc("GET /api/workflows/{id}/schedules", s.handleListWorkflowSchedules)
+	mux.HandleFunc("POST /api/workflows/{id}/schedules", s.handleCreateWorkflowSchedule)
+	mux.HandleFunc("GET /api/workflows/{id}/schedules/{schedule_id}", s.handleGetWorkflowSchedule)
+	mux.HandleFunc("PUT /api/workflows/{id}/schedules/{schedule_id}", s.handleUpdateWorkflowSchedule)
+	mux.HandleFunc("DELETE /api/workflows/{id}/schedules/{schedule_id}", s.handleDeleteWorkflowSchedule)
 	mux.HandleFunc("GET /api/runs/{run_id}/events", s.handleRunEvents)
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -16,10 +16,12 @@ import (
 // testServer creates a Server with defaults suitable for testing.
 func testServer(t *testing.T) *Server {
 	t.Helper()
+	workflowStore := newTestSQLiteStore(t)
 
 	return NewServer(ServerConfig{
-		Store:     newTestWorkflowStore(t),
-		Providers: hydrate.ProviderMap{},
+		Store:         workflowStore,
+		ScheduleStore: workflowStore,
+		Providers:     hydrate.ProviderMap{},
 		ClientFactory: func(name string, cfg hydrate.ProviderConfig) (core.LLMClient, error) {
 			return nil, nil
 		},

--- a/server/store_sqlite_test.go
+++ b/server/store_sqlite_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 var _ WorkflowStore = (*SQLiteStore)(nil)
+var _ WorkflowScheduleStore = (*SQLiteStore)(nil)
 
 func newSQLiteWorkflowStore(t *testing.T) *SQLiteStore {
 	t.Helper()
@@ -179,5 +180,199 @@ func TestSQLiteStore_PersistenceAcrossReopen(t *testing.T) {
 	}
 	if got.ID != "wf-persist" {
 		t.Fatalf("got ID = %q, want %q", got.ID, "wf-persist")
+	}
+}
+
+func TestSQLiteStore_ScheduleCRUD(t *testing.T) {
+	ctx := context.Background()
+	store := newSQLiteWorkflowStore(t)
+	mustCreateWorkflowForSchedule(t, store, "wf-schedule")
+
+	nextRun := time.Now().UTC().Add(5 * time.Minute).Round(0)
+	schedule := WorkflowSchedule{
+		ID:         "schedule-1",
+		WorkflowID: "wf-schedule",
+		Cron:       "*/5 * * * *",
+		Enabled:    true,
+		Input: map[string]any{
+			"topic": "cron",
+		},
+		Options: RunReqOptions{
+			Timeout: "30s",
+			Human: &RunReqHumanOptions{
+				Mode: "strict",
+			},
+		},
+		NextRunAt: nextRun,
+		CreatedAt: time.Now().UTC().Round(0),
+		UpdatedAt: time.Now().UTC().Round(0),
+	}
+
+	if err := store.CreateSchedule(ctx, schedule); err != nil {
+		t.Fatalf("CreateSchedule: %v", err)
+	}
+	if err := store.CreateSchedule(ctx, schedule); err != ErrWorkflowScheduleExists {
+		t.Fatalf("CreateSchedule duplicate: got %v, want ErrWorkflowScheduleExists", err)
+	}
+
+	got, found, err := store.GetSchedule(ctx, "wf-schedule", "schedule-1")
+	if err != nil {
+		t.Fatalf("GetSchedule: %v", err)
+	}
+	if !found {
+		t.Fatal("GetSchedule: expected found=true")
+	}
+	if got.Cron != "*/5 * * * *" {
+		t.Fatalf("GetSchedule cron=%q, want %q", got.Cron, "*/5 * * * *")
+	}
+	if got.NextRunAt.Format(time.RFC3339Nano) != nextRun.Format(time.RFC3339Nano) {
+		t.Fatalf("GetSchedule next_run_at=%s, want %s", got.NextRunAt, nextRun)
+	}
+	if got.Options.Timeout != "30s" {
+		t.Fatalf("GetSchedule options.timeout=%q, want %q", got.Options.Timeout, "30s")
+	}
+
+	list, err := store.ListSchedules(ctx, "wf-schedule")
+	if err != nil {
+		t.Fatalf("ListSchedules: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("ListSchedules count=%d, want 1", len(list))
+	}
+
+	updateRun := time.Now().UTC().Round(0)
+	got.Enabled = false
+	got.Cron = "0 * * * *"
+	got.LastStatus = ScheduleRunStatusCompleted
+	got.LastRunID = "run-123"
+	got.LastError = ""
+	got.LastRunAt = &updateRun
+	got.NextRunAt = updateRun.Add(time.Hour)
+	got.UpdatedAt = time.Now().UTC().Round(0)
+	if err := store.UpdateSchedule(ctx, got); err != nil {
+		t.Fatalf("UpdateSchedule: %v", err)
+	}
+
+	updated, found, err := store.GetSchedule(ctx, "wf-schedule", "schedule-1")
+	if err != nil {
+		t.Fatalf("GetSchedule updated: %v", err)
+	}
+	if !found {
+		t.Fatal("GetSchedule updated: expected found=true")
+	}
+	if updated.Enabled {
+		t.Fatal("updated.Enabled=true, want false")
+	}
+	if updated.LastStatus != ScheduleRunStatusCompleted {
+		t.Fatalf("updated.LastStatus=%q, want %q", updated.LastStatus, ScheduleRunStatusCompleted)
+	}
+	if updated.LastRunID != "run-123" {
+		t.Fatalf("updated.LastRunID=%q, want %q", updated.LastRunID, "run-123")
+	}
+
+	if err := store.DeleteSchedule(ctx, "wf-schedule", "schedule-1"); err != nil {
+		t.Fatalf("DeleteSchedule: %v", err)
+	}
+	if err := store.DeleteSchedule(ctx, "wf-schedule", "schedule-1"); err != ErrWorkflowScheduleNotFound {
+		t.Fatalf("DeleteSchedule missing: got %v, want ErrWorkflowScheduleNotFound", err)
+	}
+}
+
+func TestSQLiteStore_ListDueSchedules(t *testing.T) {
+	ctx := context.Background()
+	store := newSQLiteWorkflowStore(t)
+	mustCreateWorkflowForSchedule(t, store, "wf-a")
+	mustCreateWorkflowForSchedule(t, store, "wf-b")
+
+	now := time.Now().UTC().Round(0)
+	s1 := WorkflowSchedule{
+		ID:         "due-1",
+		WorkflowID: "wf-a",
+		Cron:       "* * * * *",
+		Enabled:    true,
+		NextRunAt:  now.Add(-2 * time.Minute),
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	s2 := WorkflowSchedule{
+		ID:         "due-2",
+		WorkflowID: "wf-b",
+		Cron:       "* * * * *",
+		Enabled:    true,
+		NextRunAt:  now.Add(-1 * time.Minute),
+		CreatedAt:  now.Add(time.Second),
+		UpdatedAt:  now.Add(time.Second),
+	}
+	s3 := WorkflowSchedule{
+		ID:         "future",
+		WorkflowID: "wf-a",
+		Cron:       "* * * * *",
+		Enabled:    true,
+		NextRunAt:  now.Add(2 * time.Minute),
+		CreatedAt:  now.Add(2 * time.Second),
+		UpdatedAt:  now.Add(2 * time.Second),
+	}
+
+	for _, schedule := range []WorkflowSchedule{s1, s2, s3} {
+		if err := store.CreateSchedule(ctx, schedule); err != nil {
+			t.Fatalf("CreateSchedule(%s): %v", schedule.ID, err)
+		}
+	}
+
+	due, err := store.ListDueSchedules(ctx, now, 10)
+	if err != nil {
+		t.Fatalf("ListDueSchedules: %v", err)
+	}
+	if len(due) != 2 {
+		t.Fatalf("ListDueSchedules count=%d, want 2", len(due))
+	}
+	if due[0].ID != "due-1" || due[1].ID != "due-2" {
+		t.Fatalf("ListDueSchedules order=%v, want [due-1 due-2]", []string{due[0].ID, due[1].ID})
+	}
+}
+
+func TestSQLiteStore_DeleteWorkflowCascadesSchedules(t *testing.T) {
+	ctx := context.Background()
+	store := newSQLiteWorkflowStore(t)
+	mustCreateWorkflowForSchedule(t, store, "wf-cascade")
+
+	schedule := WorkflowSchedule{
+		ID:         "cascade-1",
+		WorkflowID: "wf-cascade",
+		Cron:       "* * * * *",
+		Enabled:    true,
+		NextRunAt:  time.Now().UTC().Add(time.Minute).Round(0),
+		CreatedAt:  time.Now().UTC().Round(0),
+		UpdatedAt:  time.Now().UTC().Round(0),
+	}
+	if err := store.CreateSchedule(ctx, schedule); err != nil {
+		t.Fatalf("CreateSchedule: %v", err)
+	}
+
+	if err := store.Delete(ctx, "wf-cascade"); err != nil {
+		t.Fatalf("Delete workflow: %v", err)
+	}
+
+	_, found, err := store.GetSchedule(ctx, "wf-cascade", "cascade-1")
+	if err != nil {
+		t.Fatalf("GetSchedule after workflow delete: %v", err)
+	}
+	if found {
+		t.Fatal("GetSchedule found=true after workflow delete, want false")
+	}
+}
+
+func mustCreateWorkflowForSchedule(t *testing.T, store *SQLiteStore, workflowID string) {
+	t.Helper()
+
+	err := store.Create(context.Background(), WorkflowRecord{
+		ID:         workflowID,
+		SchemaKind: loader.SchemaKindGraph,
+		Source:     json.RawMessage(`{"id":"` + workflowID + `","version":"1.0","nodes":[{"id":"n1","type":"func"}],"edges":[],"entry":"n1"}`),
+		CreatedAt:  time.Now().UTC().Round(0),
+		UpdatedAt:  time.Now().UTC().Round(0),
+	})
+	if err != nil {
+		t.Fatalf("Create workflow %s: %v", workflowID, err)
 	}
 }

--- a/server/test_sqlite_helpers_test.go
+++ b/server/test_sqlite_helpers_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/petal-labs/petalflow/tool"
 )
 
-func newTestWorkflowStore(t *testing.T) WorkflowStore {
+func newTestSQLiteStore(t *testing.T) *SQLiteStore {
 	t.Helper()
 
 	path := filepath.Join(t.TempDir(), "workflows.sqlite")
@@ -18,6 +18,11 @@ func newTestWorkflowStore(t *testing.T) WorkflowStore {
 	}
 	t.Cleanup(func() { _ = store.Close() })
 	return store
+}
+
+func newTestWorkflowStore(t *testing.T) WorkflowStore {
+	t.Helper()
+	return newTestSQLiteStore(t)
 }
 
 func newTestEventStore(t *testing.T) bus.EventStore {

--- a/server/workflow_scheduler.go
+++ b/server/workflow_scheduler.go
@@ -1,0 +1,285 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+const (
+	defaultWorkflowSchedulePollInterval = 5 * time.Second
+	defaultWorkflowScheduleBatchLimit   = 100
+)
+
+// WorkflowSchedulerConfig configures the background workflow schedule runner.
+type WorkflowSchedulerConfig struct {
+	Runner       *Server
+	Store        WorkflowScheduleStore
+	PollInterval time.Duration
+	BatchLimit   int
+	Now          func() time.Time
+	Logger       *slog.Logger
+}
+
+// WorkflowScheduler periodically executes due workflow schedules.
+type WorkflowScheduler struct {
+	runner       *Server
+	store        WorkflowScheduleStore
+	pollInterval time.Duration
+	batchLimit   int
+	now          func() time.Time
+	logger       *slog.Logger
+
+	mu     sync.Mutex
+	active map[string]struct{}
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// NewWorkflowScheduler creates a workflow scheduler instance.
+func NewWorkflowScheduler(cfg WorkflowSchedulerConfig) (*WorkflowScheduler, error) {
+	if cfg.Runner == nil {
+		return nil, errors.New("workflow scheduler runner is nil")
+	}
+	if cfg.Store == nil {
+		return nil, errors.New("workflow scheduler store is nil")
+	}
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = defaultWorkflowSchedulePollInterval
+	}
+	if cfg.BatchLimit <= 0 {
+		cfg.BatchLimit = defaultWorkflowScheduleBatchLimit
+	}
+	if cfg.Now == nil {
+		cfg.Now = func() time.Time { return time.Now().UTC() }
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+
+	return &WorkflowScheduler{
+		runner:       cfg.Runner,
+		store:        cfg.Store,
+		pollInterval: cfg.PollInterval,
+		batchLimit:   cfg.BatchLimit,
+		now:          cfg.Now,
+		logger:       cfg.Logger,
+		active:       map[string]struct{}{},
+	}, nil
+}
+
+// Start starts background polling.
+func (s *WorkflowScheduler) Start(ctx context.Context) error {
+	if s == nil {
+		return errors.New("workflow scheduler is nil")
+	}
+
+	s.mu.Lock()
+	if s.cancel != nil {
+		s.mu.Unlock()
+		return nil
+	}
+	loopCtx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	s.cancel = cancel
+	s.done = done
+	s.mu.Unlock()
+
+	go func() {
+		defer close(done)
+		_ = s.RunOnce(loopCtx)
+		ticker := time.NewTicker(s.pollInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-loopCtx.Done():
+				return
+			case <-ticker.C:
+				_ = s.RunOnce(loopCtx)
+			}
+		}
+	}()
+
+	_ = ctx
+	return nil
+}
+
+// Stop stops background polling.
+func (s *WorkflowScheduler) Stop(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+
+	s.mu.Lock()
+	cancel := s.cancel
+	done := s.done
+	s.cancel = nil
+	s.done = nil
+	s.mu.Unlock()
+
+	if cancel == nil {
+		return nil
+	}
+	cancel()
+
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// RunOnce executes a single scheduler pass.
+func (s *WorkflowScheduler) RunOnce(ctx context.Context) error {
+	if s == nil || s.store == nil || s.runner == nil {
+		return errors.New("workflow scheduler is not configured")
+	}
+
+	now := s.now().UTC()
+	dueSchedules, err := s.store.ListDueSchedules(ctx, now, s.batchLimit)
+	if err != nil {
+		return err
+	}
+
+	for _, schedule := range dueSchedules {
+		s.processDueSchedule(ctx, schedule, now)
+	}
+	return nil
+}
+
+func (s *WorkflowScheduler) processDueSchedule(ctx context.Context, schedule WorkflowSchedule, now time.Time) {
+	if !schedule.Enabled {
+		return
+	}
+
+	if s.isScheduleActive(schedule.ID) {
+		s.markSkippedOverlap(ctx, schedule, now)
+		return
+	}
+
+	nextRunAt, err := nextCronRunUTC(schedule.Cron, now)
+	if err != nil {
+		s.markScheduleFailure(ctx, schedule, now, fmt.Errorf("invalid cron expression: %w", err))
+		return
+	}
+
+	schedule.NextRunAt = nextRunAt
+	schedule.LastStatus = ScheduleRunStatusRunning
+	schedule.LastError = ""
+	schedule.UpdatedAt = now
+	if err := s.store.UpdateSchedule(ctx, schedule); err != nil {
+		s.logger.Error("update schedule before run", "schedule_id", schedule.ID, "workflow_id", schedule.WorkflowID, "error", err)
+		return
+	}
+
+	s.markScheduleActive(schedule.ID)
+	go s.runSchedule(schedule, now)
+}
+
+func (s *WorkflowScheduler) runSchedule(schedule WorkflowSchedule, scheduledAt time.Time) {
+	defer s.unmarkScheduleActive(schedule.ID)
+
+	runReq := RunRequest{
+		Input:   cloneMapAny(schedule.Input),
+		Options: schedule.Options,
+	}
+	runReq.Options.Stream = false
+
+	resp, runErr := s.runner.runScheduledWorkflow(context.Background(), schedule.WorkflowID, runReq, scheduledRunMetadata{
+		ScheduleID:  schedule.ID,
+		WorkflowID:  schedule.WorkflowID,
+		ScheduledAt: scheduledAt,
+	})
+
+	finish := s.now().UTC()
+	latest, found, err := s.store.GetSchedule(context.Background(), schedule.WorkflowID, schedule.ID)
+	if err != nil {
+		s.logger.Error("load schedule after run", "schedule_id", schedule.ID, "workflow_id", schedule.WorkflowID, "error", err)
+		return
+	}
+	if !found {
+		return
+	}
+
+	latest.UpdatedAt = finish
+	latest.LastRunAt = &finish
+	if runErr != nil {
+		latest.LastStatus = ScheduleRunStatusFailed
+		latest.LastError = runErr.Error()
+	} else {
+		latest.LastStatus = ScheduleRunStatusCompleted
+		latest.LastError = ""
+		latest.LastRunID = resp.RunID
+	}
+
+	if err := s.store.UpdateSchedule(context.Background(), latest); err != nil {
+		s.logger.Error("persist schedule run result", "schedule_id", schedule.ID, "workflow_id", schedule.WorkflowID, "error", err)
+	}
+}
+
+func (s *WorkflowScheduler) markSkippedOverlap(ctx context.Context, schedule WorkflowSchedule, now time.Time) {
+	nextRunAt, err := nextCronRunUTC(schedule.Cron, now)
+	if err != nil {
+		s.markScheduleFailure(ctx, schedule, now, fmt.Errorf("invalid cron expression: %w", err))
+		return
+	}
+
+	schedule.NextRunAt = nextRunAt
+	schedule.LastStatus = ScheduleRunStatusSkippedOverlap
+	schedule.LastError = "skipped because prior scheduled run is still active"
+	schedule.UpdatedAt = now
+	if err := s.store.UpdateSchedule(ctx, schedule); err != nil {
+		s.logger.Error("persist overlap skip", "schedule_id", schedule.ID, "workflow_id", schedule.WorkflowID, "error", err)
+	}
+}
+
+func (s *WorkflowScheduler) markScheduleFailure(ctx context.Context, schedule WorkflowSchedule, now time.Time, runErr error) {
+	nextRunAt, nextErr := nextCronRunUTC(schedule.Cron, now)
+	if nextErr == nil {
+		schedule.NextRunAt = nextRunAt
+	}
+	schedule.LastStatus = ScheduleRunStatusFailed
+	schedule.LastError = runErr.Error()
+	schedule.UpdatedAt = now
+	if err := s.store.UpdateSchedule(ctx, schedule); err != nil {
+		s.logger.Error("persist schedule failure", "schedule_id", schedule.ID, "workflow_id", schedule.WorkflowID, "error", err)
+	}
+}
+
+func (s *WorkflowScheduler) isScheduleActive(scheduleID string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.active[scheduleID]
+	return ok
+}
+
+func (s *WorkflowScheduler) markScheduleActive(scheduleID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.active[scheduleID] = struct{}{}
+}
+
+func (s *WorkflowScheduler) unmarkScheduleActive(scheduleID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.active, scheduleID)
+}
+
+func cloneMapAny(in map[string]any) map[string]any {
+	if in == nil {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for key, value := range in {
+		out[key] = value
+	}
+	return out
+}

--- a/server/workflow_scheduler_test.go
+++ b/server/workflow_scheduler_test.go
@@ -1,0 +1,172 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/petalflow/bus"
+	"github.com/petal-labs/petalflow/core"
+	"github.com/petal-labs/petalflow/hydrate"
+)
+
+func TestWorkflowScheduler_RunOnceExecutesDueSchedule(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	eventStore := newTestEventStore(t)
+	srv := NewServer(ServerConfig{
+		Store:         store,
+		ScheduleStore: store,
+		Providers:     hydrate.ProviderMap{},
+		ClientFactory: func(name string, cfg hydrate.ProviderConfig) (core.LLMClient, error) { return nil, nil },
+		Bus:           bus.NewMemBus(bus.MemBusConfig{}),
+		EventStore:    eventStore,
+	})
+	createWorkflowForScheduler(t, srv.Handler(), "scheduler-run")
+
+	now := time.Date(2026, 2, 16, 12, 0, 0, 0, time.UTC)
+	schedule := WorkflowSchedule{
+		ID:         "sched-run",
+		WorkflowID: "scheduler-run",
+		Cron:       "* * * * *",
+		Enabled:    true,
+		Input:      map[string]any{"x": "y"},
+		NextRunAt:  now.Add(-time.Minute),
+		CreatedAt:  now.Add(-time.Hour),
+		UpdatedAt:  now.Add(-time.Hour),
+	}
+	if err := store.CreateSchedule(context.Background(), schedule); err != nil {
+		t.Fatalf("CreateSchedule: %v", err)
+	}
+
+	scheduler, err := NewWorkflowScheduler(WorkflowSchedulerConfig{
+		Runner:       srv,
+		Store:        store,
+		PollInterval: time.Second,
+		Now:          func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewWorkflowScheduler: %v", err)
+	}
+
+	if err := scheduler.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	updated := waitForScheduleStatus(t, store, "scheduler-run", "sched-run", 2*time.Second)
+	if updated.LastStatus != ScheduleRunStatusCompleted {
+		t.Fatalf("last_status=%q, want %q", updated.LastStatus, ScheduleRunStatusCompleted)
+	}
+	if updated.LastRunID == "" {
+		t.Fatal("last_run_id is empty")
+	}
+	if updated.LastRunAt == nil || updated.LastRunAt.IsZero() {
+		t.Fatal("last_run_at is nil/zero")
+	}
+	if !updated.NextRunAt.After(now) {
+		t.Fatalf("next_run_at=%s, want > %s", updated.NextRunAt, now)
+	}
+
+	events, err := eventStore.List(context.Background(), updated.LastRunID, 0, 0)
+	if err != nil {
+		t.Fatalf("eventStore.List: %v", err)
+	}
+	foundTrigger := false
+	for _, event := range events {
+		if event.Kind != "run.started" {
+			continue
+		}
+		if event.Payload["trigger"] == "schedule" && event.Payload["schedule_id"] == "sched-run" {
+			foundTrigger = true
+			break
+		}
+	}
+	if !foundTrigger {
+		t.Fatalf("expected run.started event with schedule metadata; events=%v", events)
+	}
+}
+
+func TestWorkflowScheduler_SkipsOverlapWhenRunAlreadyActive(t *testing.T) {
+	store := newTestSQLiteStore(t)
+	srv := NewServer(ServerConfig{
+		Store:         store,
+		ScheduleStore: store,
+		Providers:     hydrate.ProviderMap{},
+		ClientFactory: func(name string, cfg hydrate.ProviderConfig) (core.LLMClient, error) { return nil, nil },
+	})
+	createWorkflowForScheduler(t, srv.Handler(), "scheduler-overlap")
+
+	now := time.Date(2026, 2, 16, 12, 0, 0, 0, time.UTC)
+	schedule := WorkflowSchedule{
+		ID:         "sched-overlap",
+		WorkflowID: "scheduler-overlap",
+		Cron:       "* * * * *",
+		Enabled:    true,
+		NextRunAt:  now.Add(-time.Minute),
+		CreatedAt:  now.Add(-time.Hour),
+		UpdatedAt:  now.Add(-time.Hour),
+	}
+	if err := store.CreateSchedule(context.Background(), schedule); err != nil {
+		t.Fatalf("CreateSchedule: %v", err)
+	}
+
+	scheduler, err := NewWorkflowScheduler(WorkflowSchedulerConfig{
+		Runner: srv,
+		Store:  store,
+		Now:    func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewWorkflowScheduler: %v", err)
+	}
+	scheduler.markScheduleActive("sched-overlap")
+	defer scheduler.unmarkScheduleActive("sched-overlap")
+
+	if err := scheduler.RunOnce(context.Background()); err != nil {
+		t.Fatalf("RunOnce: %v", err)
+	}
+
+	updated, found, err := store.GetSchedule(context.Background(), "scheduler-overlap", "sched-overlap")
+	if err != nil {
+		t.Fatalf("GetSchedule: %v", err)
+	}
+	if !found {
+		t.Fatal("GetSchedule found=false")
+	}
+	if updated.LastStatus != ScheduleRunStatusSkippedOverlap {
+		t.Fatalf("last_status=%q, want %q", updated.LastStatus, ScheduleRunStatusSkippedOverlap)
+	}
+	if !updated.NextRunAt.After(now) {
+		t.Fatalf("next_run_at=%s, want > %s", updated.NextRunAt, now)
+	}
+}
+
+func createWorkflowForScheduler(t *testing.T, handler http.Handler, workflowID string) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/workflows/graph", bytes.NewReader(validGraphJSON(workflowID)))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("create workflow status=%d, want %d body=%s", w.Code, http.StatusCreated, w.Body.String())
+	}
+}
+
+func waitForScheduleStatus(t *testing.T, store WorkflowScheduleStore, workflowID, scheduleID string, timeout time.Duration) WorkflowSchedule {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		schedule, found, err := store.GetSchedule(context.Background(), workflowID, scheduleID)
+		if err != nil {
+			t.Fatalf("GetSchedule: %v", err)
+		}
+		if found && (schedule.LastStatus == ScheduleRunStatusCompleted || schedule.LastStatus == ScheduleRunStatusFailed || schedule.LastStatus == ScheduleRunStatusSkippedOverlap) {
+			return schedule
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timeout waiting for schedule status for %s", scheduleID)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds first-class workflow scheduling to PetalFlow daemon mode using standard Unix cron expressions. Users can now persist schedules on workflows and let `petalflow serve` execute them automatically.

The implementation follows the approved product constraints:

- UTC-only cron scheduling (no local timezone scheduling)
- missed runs are skipped (no backfill)
- overlap policy is skip-while-running for the same schedule
- scheduled runs default to strict human handling (and may fail on human nodes)
- multi-daemon scheduling against one SQLite DB is documented as a known limitation

## User impact
Before this change, users had to externally orchestrate daemon run endpoints if they wanted recurring executions. This introduced drift and duplicated reliability logic in external systems.

After this change, users can manage schedules directly through daemon workflow APIs and rely on a built-in scheduler loop for execution.

## Root cause
PetalFlow had no persisted schedule model or scheduler loop for workflows. The runtime and daemon only supported on-demand execution (`POST /api/workflows/{id}/run`) and tool-health periodic tasks.

## What changed
### Persistence and model
- Added `WorkflowSchedule` model and store interface in `server/schedule_store.go`.
- Extended SQLite workflow schema with `workflow_schedules` table, indexes, and CRUD/due-list operations in `server/store_sqlite.go`.
- Added schedule persistence tests in `server/store_sqlite_test.go`.

### Cron parsing and validation
- Added UTC-only cron parser utilities in `server/cron.go`.
- Enforced standard 5-field Unix cron format.
- Explicitly reject timezone-prefixed cron expressions (`CRON_TZ=`, `TZ=`).

### API surface
- Added workflow schedule endpoints:
  - `GET /api/workflows/{id}/schedules`
  - `POST /api/workflows/{id}/schedules`
  - `GET /api/workflows/{id}/schedules/{schedule_id}`
  - `PUT /api/workflows/{id}/schedules/{schedule_id}`
  - `DELETE /api/workflows/{id}/schedules/{schedule_id}`
- Added request validation for schedule input/options:
  - `options.stream` is rejected for scheduled runs
  - `options.timeout` validated as Go duration
  - `options.human` validated with existing human mode rules

### Scheduler runtime
- Added background workflow scheduler in `server/workflow_scheduler.go`.
- Wired scheduler lifecycle into `petalflow serve` in `cli/serve.go`.
- Added serve flag: `--workflow-schedule-poll`.
- Scheduler behavior:
  - polls due schedules in UTC
  - skips missed windows (no backfill)
  - skips overlap if prior run for that schedule is still active
  - updates schedule status/history fields (`running`, `completed`, `failed`, `skipped_overlap`)

### Run-path reuse and observability
- Extracted shared run planning/execution flow to `server/run_service.go` so scheduled runs and API runs use the same execution path.
- Added scheduled-run metadata to run events (`trigger=schedule`, `schedule_id`, `workflow_id`, `scheduled_at`).
- Updated OTel tracing and metrics attribute enrichment for schedule-triggered runs (`otel/tracing.go`, `otel/metrics.go`).

### Docs
- Updated daemon API docs with schedule endpoints and behavior constraints in `docs/daemon-api.md`.
- Fixed stale persistence wording to SQLite-backed storage.
- Added README note pointing to daemon schedule support.

## Known limitation
Multi-daemon scheduling against the same SQLite database is not coordinated in this release. Documentation now warns users to run one scheduler instance per DB.

## Validation
- `go test ./... -count=1`
- Added/updated tests:
  - `server/cron_test.go`
  - `server/schedule_handlers_test.go`
  - `server/workflow_scheduler_test.go`
  - `server/store_sqlite_test.go`
