### PR TITLE
ci: bump codecov-action off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: go test -race ./...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out


### PR DESCRIPTION
## Summary

Follow-up to #135. That PR cleared the Node 20 deprecation for `checkout`, `setup-go`, the artifact actions, and `action-gh-release`, but it merged before the `codecov/codecov-action` bump landed on the branch — so main still pins `codecov/codecov-action@v4`, which the CI run flagged as targeting the deprecated Node 20 runtime.

## Change

| Action | Before | After |
|--------|--------|-------|
| `codecov/codecov-action` | v4 | **v7** |

Our inputs (`token`, `files`, `fail_ci_if_error`) are unchanged across the bump — v5 only deprecated `file` (→ `files`) and `plugin` (→ `plugins`), neither of which is used.

## Remaining

`golangci/golangci-lint-action@v7` is the last Node 20 action; it requires a coupled golangci-lint upgrade and is tracked in #136.

## Verification

- ci.yml validated as parseable YAML
- The codecov upload step runs in this PR's own `ci.yml` Test job, exercising the bump directly