### PR TITLE
fix: surface node errors in envelope JSON output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Node errors are now surfaced to callers.** The `EnvelopeJSON` wire contract
+  (used by `petalflow run --format json` and the daemon HTTP API) previously
+  dropped the envelope's recorded node errors entirely, so runs that continued
+  past a failed node returned a success-looking result with no trace of the
+  failure. `EnvelopeJSON` now includes an `errors` array, and the `pretty` CLI
+  output prints an `Errors` section.
+
+### Changed
+
+- **Completed the `EnvelopeJSON` wire contract.** Added `input`, per-message and
+  per-artifact `meta`, and trace `parent_id`/`span_id`, which were previously
+  discarded during serialization.
+
 ## [0.3.0] - 2026-07-31
 
 ### Added

--- a/cli/run.go
+++ b/cli/run.go
@@ -356,6 +356,13 @@ func formatPretty(env *core.Envelope) string {
 		}
 	}
 
+	if len(env.Errors) > 0 {
+		sb.WriteString(fmt.Sprintf("\n=== Errors (%d) ===\n", len(env.Errors)))
+		for _, e := range env.Errors {
+			sb.WriteString(fmt.Sprintf("  [%s] %s: %s\n", e.Kind, e.NodeID, e.Message))
+		}
+	}
+
 	if env.Trace.RunID != "" {
 		sb.WriteString("\n=== Trace ===\n")
 		sb.WriteString(fmt.Sprintf("  Run ID: %s\n", env.Trace.RunID))

--- a/cli/run_internal_test.go
+++ b/cli/run_internal_test.go
@@ -11,10 +11,33 @@ import (
 	"testing"
 	"time"
 
+	"github.com/petal-labs/petalflow/core"
 	"github.com/petal-labs/petalflow/registry"
 	"github.com/petal-labs/petalflow/runtime"
 	"github.com/petal-labs/petalflow/tool"
 )
+
+func TestFormatPretty_SurfacesErrors(t *testing.T) {
+	env := core.NewEnvelope()
+	env.SetVar("result", "ok")
+	env.AppendError(core.NodeError{
+		NodeID:  "tool-1",
+		Kind:    core.NodeKindTool,
+		Message: "tool failed",
+	})
+
+	out := formatPretty(env)
+
+	if !strings.Contains(out, "Errors") {
+		t.Errorf("expected an Errors section, got:\n%s", out)
+	}
+	if !strings.Contains(out, "tool-1") {
+		t.Errorf("expected failing node id in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "tool failed") {
+		t.Errorf("expected error message in output, got:\n%s", out)
+	}
+}
 
 func TestBuildRunOptions_NonStreaming(t *testing.T) {
 	cmd := NewRunCmd()

--- a/server/envelope_adapter.go
+++ b/server/envelope_adapter.go
@@ -8,29 +8,53 @@ import (
 )
 
 // EnvelopeJSON is the JSON-serializable representation of an Envelope.
+//
+// This is the stable wire contract returned by the CLI (petalflow run --format
+// json) and the daemon HTTP API. It intentionally mirrors every field of
+// core.Envelope that a caller needs to observe a run's outcome, including any
+// node Errors recorded during continue-on-error execution. Dropping Errors here
+// would make failed nodes invisible to callers, so they are always surfaced.
 type EnvelopeJSON struct {
-	Vars      map[string]any `json:"vars"`
-	Messages  []MessageJSON  `json:"messages,omitempty"`
-	Artifacts []ArtifactJSON `json:"artifacts,omitempty"`
-	Trace     *TraceJSON     `json:"trace,omitempty"`
+	Input     any             `json:"input,omitempty"`
+	Vars      map[string]any  `json:"vars"`
+	Messages  []MessageJSON   `json:"messages,omitempty"`
+	Artifacts []ArtifactJSON  `json:"artifacts,omitempty"`
+	Errors    []NodeErrorJSON `json:"errors,omitempty"`
+	Trace     *TraceJSON      `json:"trace,omitempty"`
 }
 
 // MessageJSON is the JSON-serializable representation of a Message.
 type MessageJSON struct {
-	Role    string `json:"role"`
-	Content string `json:"content"`
-	Name    string `json:"name,omitempty"`
+	Role    string         `json:"role"`
+	Content string         `json:"content"`
+	Name    string         `json:"name,omitempty"`
+	Meta    map[string]any `json:"meta,omitempty"`
 }
 
 // ArtifactJSON is the JSON-serializable representation of an Artifact.
 type ArtifactJSON struct {
-	ID       string `json:"id,omitempty"`
-	Name     string `json:"name,omitempty"`
-	Type     string `json:"type"`
-	MimeType string `json:"mime_type,omitempty"`
-	Text     string `json:"text,omitempty"`
-	Content  string `json:"content,omitempty"` // base64 for binary data
-	URI      string `json:"uri,omitempty"`
+	ID       string         `json:"id,omitempty"`
+	Name     string         `json:"name,omitempty"`
+	Type     string         `json:"type"`
+	MimeType string         `json:"mime_type,omitempty"`
+	Text     string         `json:"text,omitempty"`
+	Content  string         `json:"content,omitempty"` // base64 for binary data
+	URI      string         `json:"uri,omitempty"`
+	Meta     map[string]any `json:"meta,omitempty"`
+}
+
+// NodeErrorJSON is the JSON-serializable representation of a core.NodeError.
+// It surfaces errors that were recorded on the envelope while the run continued
+// (continue-on-error / record policies) so callers can see which nodes failed
+// and why.
+type NodeErrorJSON struct {
+	NodeID  string         `json:"node_id"`
+	Kind    string         `json:"kind,omitempty"`
+	Message string         `json:"message"`
+	Attempt int            `json:"attempt,omitempty"`
+	At      string         `json:"at,omitempty"` // RFC3339
+	Details map[string]any `json:"details,omitempty"`
+	Cause   string         `json:"cause,omitempty"` // underlying cause, when distinct
 }
 
 // TraceJSON is the JSON-serializable representation of TraceInfo.
@@ -38,6 +62,8 @@ type TraceJSON struct {
 	RunID     string `json:"run_id"`
 	StartedAt string `json:"started_at,omitempty"`
 	TraceID   string `json:"trace_id,omitempty"`
+	ParentID  string `json:"parent_id,omitempty"`
+	SpanID    string `json:"span_id,omitempty"`
 }
 
 // EnvelopeToJSON converts a live Envelope to the JSON-serializable form.
@@ -47,7 +73,8 @@ func EnvelopeToJSON(env *core.Envelope) EnvelopeJSON {
 	}
 
 	result := EnvelopeJSON{
-		Vars: env.Vars,
+		Input: env.Input,
+		Vars:  env.Vars,
 	}
 	if result.Vars == nil {
 		result.Vars = make(map[string]any)
@@ -59,6 +86,7 @@ func EnvelopeToJSON(env *core.Envelope) EnvelopeJSON {
 			Role:    msg.Role,
 			Content: msg.Content,
 			Name:    msg.Name,
+			Meta:    msg.Meta,
 		})
 	}
 
@@ -71,6 +99,7 @@ func EnvelopeToJSON(env *core.Envelope) EnvelopeJSON {
 			MimeType: art.MimeType,
 			Text:     art.Text,
 			URI:      art.URI,
+			Meta:     art.Meta,
 		}
 		// Base64-encode binary content.
 		if len(art.Bytes) > 0 {
@@ -79,11 +108,18 @@ func EnvelopeToJSON(env *core.Envelope) EnvelopeJSON {
 		result.Artifacts = append(result.Artifacts, aj)
 	}
 
+	// Convert node errors so failed nodes remain visible to callers.
+	for _, nodeErr := range env.Errors {
+		result.Errors = append(result.Errors, nodeErrorToJSON(nodeErr))
+	}
+
 	// Convert trace.
 	if env.Trace.RunID != "" {
 		tj := &TraceJSON{
-			RunID:   env.Trace.RunID,
-			TraceID: env.Trace.TraceID,
+			RunID:    env.Trace.RunID,
+			TraceID:  env.Trace.TraceID,
+			ParentID: env.Trace.ParentID,
+			SpanID:   env.Trace.SpanID,
 		}
 		if !env.Trace.Started.IsZero() {
 			tj.StartedAt = env.Trace.Started.Format(time.RFC3339)
@@ -92,6 +128,26 @@ func EnvelopeToJSON(env *core.Envelope) EnvelopeJSON {
 	}
 
 	return result
+}
+
+// nodeErrorToJSON converts a core.NodeError to its wire representation.
+// The underlying cause is surfaced as a string only when it adds information
+// beyond Message (nodes commonly set Message = cause.Error()).
+func nodeErrorToJSON(e core.NodeError) NodeErrorJSON {
+	out := NodeErrorJSON{
+		NodeID:  e.NodeID,
+		Kind:    string(e.Kind),
+		Message: e.Message,
+		Attempt: e.Attempt,
+		Details: e.Details,
+	}
+	if !e.At.IsZero() {
+		out.At = e.At.Format(time.RFC3339)
+	}
+	if e.Cause != nil && e.Cause.Error() != e.Message {
+		out.Cause = e.Cause.Error()
+	}
+	return out
 }
 
 // EnvelopeFromJSON converts JSON input data into an Envelope.

--- a/server/envelope_adapter_test.go
+++ b/server/envelope_adapter_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 	"time"
 
@@ -306,6 +307,178 @@ func TestRoundTrip(t *testing.T) {
 		if got != want {
 			t.Errorf("var %q = %v, want %v", k, got, want)
 		}
+	}
+}
+
+func TestEnvelopeToJSON_WithErrors(t *testing.T) {
+	env := core.NewEnvelope()
+	env.Trace = core.TraceInfo{}
+	env.AppendError(core.NodeError{
+		NodeID:  "tool-1",
+		Kind:    core.NodeKindTool,
+		Message: "tool failed",
+		Attempt: 2,
+		At:      time.Date(2026, 2, 7, 12, 0, 0, 0, time.UTC),
+		Details: map[string]any{"tool": "search"},
+		Cause:   errors.New("connection refused"),
+	})
+
+	result := EnvelopeToJSON(env)
+
+	if len(result.Errors) != 1 {
+		t.Fatalf("expected 1 error, got %d", len(result.Errors))
+	}
+	e := result.Errors[0]
+	if e.NodeID != "tool-1" {
+		t.Errorf("error.NodeID = %q, want %q", e.NodeID, "tool-1")
+	}
+	if e.Kind != "tool" {
+		t.Errorf("error.Kind = %q, want %q", e.Kind, "tool")
+	}
+	if e.Message != "tool failed" {
+		t.Errorf("error.Message = %q, want %q", e.Message, "tool failed")
+	}
+	if e.Attempt != 2 {
+		t.Errorf("error.Attempt = %d, want %d", e.Attempt, 2)
+	}
+	if e.At != "2026-02-07T12:00:00Z" {
+		t.Errorf("error.At = %q, want %q", e.At, "2026-02-07T12:00:00Z")
+	}
+	if e.Details["tool"] != "search" {
+		t.Errorf("error.Details[tool] = %v, want %q", e.Details["tool"], "search")
+	}
+	if e.Cause != "connection refused" {
+		t.Errorf("error.Cause = %q, want %q", e.Cause, "connection refused")
+	}
+}
+
+func TestEnvelopeToJSON_ErrorsMarshalToJSON(t *testing.T) {
+	env := core.NewEnvelope()
+	env.Trace = core.TraceInfo{}
+	env.AppendError(core.NodeError{
+		NodeID:  "llm-1",
+		Kind:    core.NodeKindLLM,
+		Message: "boom",
+	})
+
+	data, err := json.Marshal(EnvelopeToJSON(env))
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+
+	errs, ok := decoded["errors"].([]any)
+	if !ok {
+		t.Fatalf("expected errors array in JSON output, got %T", decoded["errors"])
+	}
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error entry, got %d", len(errs))
+	}
+	entry, ok := errs[0].(map[string]any)
+	if !ok {
+		t.Fatalf("error entry should be a JSON object, got %T", errs[0])
+	}
+	if entry["node_id"] != "llm-1" {
+		t.Errorf("errors[0].node_id = %v, want %q", entry["node_id"], "llm-1")
+	}
+	if entry["message"] != "boom" {
+		t.Errorf("errors[0].message = %v, want %q", entry["message"], "boom")
+	}
+}
+
+func TestEnvelopeToJSON_OmitsErrorsWhenNone(t *testing.T) {
+	env := core.NewEnvelope()
+	env.Trace = core.TraceInfo{}
+
+	data, err := json.Marshal(EnvelopeToJSON(env))
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if _, ok := decoded["errors"]; ok {
+		t.Error("errors key should be omitted when there are no errors")
+	}
+}
+
+func TestEnvelopeToJSON_PreservesMessageMeta(t *testing.T) {
+	env := core.NewEnvelope()
+	env.Trace = core.TraceInfo{}
+	env.AppendMessage(core.Message{
+		Role:    "assistant",
+		Content: "hi",
+		Meta:    map[string]any{"model": "gpt", "provider": "openai"},
+	})
+
+	result := EnvelopeToJSON(env)
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+	if result.Messages[0].Meta["model"] != "gpt" {
+		t.Errorf("message.Meta[model] = %v, want %q", result.Messages[0].Meta["model"], "gpt")
+	}
+	if result.Messages[0].Meta["provider"] != "openai" {
+		t.Errorf("message.Meta[provider] = %v, want %q", result.Messages[0].Meta["provider"], "openai")
+	}
+}
+
+func TestEnvelopeToJSON_PreservesArtifactMeta(t *testing.T) {
+	env := core.NewEnvelope()
+	env.Trace = core.TraceInfo{}
+	env.AppendArtifact(core.Artifact{
+		ID:   "a1",
+		Type: "json",
+		Meta: map[string]any{"confidence": 0.9},
+	})
+
+	result := EnvelopeToJSON(env)
+
+	if len(result.Artifacts) != 1 {
+		t.Fatalf("expected 1 artifact, got %d", len(result.Artifacts))
+	}
+	if result.Artifacts[0].Meta["confidence"] != 0.9 {
+		t.Errorf("artifact.Meta[confidence] = %v, want %v", result.Artifacts[0].Meta["confidence"], 0.9)
+	}
+}
+
+func TestEnvelopeToJSON_PreservesInput(t *testing.T) {
+	env := core.NewEnvelope()
+	env.Trace = core.TraceInfo{}
+	env.Input = "primary payload"
+
+	result := EnvelopeToJSON(env)
+
+	if result.Input != "primary payload" {
+		t.Errorf("Input = %v, want %q", result.Input, "primary payload")
+	}
+}
+
+func TestEnvelopeToJSON_PreservesTraceParentAndSpan(t *testing.T) {
+	env := core.NewEnvelope()
+	env.Trace = core.TraceInfo{
+		RunID:    "run-1",
+		ParentID: "parent-1",
+		SpanID:   "span-1",
+	}
+
+	result := EnvelopeToJSON(env)
+
+	if result.Trace == nil {
+		t.Fatal("expected non-nil Trace")
+	}
+	if result.Trace.ParentID != "parent-1" {
+		t.Errorf("Trace.ParentID = %q, want %q", result.Trace.ParentID, "parent-1")
+	}
+	if result.Trace.SpanID != "span-1" {
+		t.Errorf("Trace.SpanID = %q, want %q", result.Trace.SpanID, "span-1")
 	}
 }
 


### PR DESCRIPTION
## Problem

The `EnvelopeJSON` wire contract shared by the CLI (`petalflow run --format json`) and the daemon HTTP API had **no field for node errors**. When a run continued past a failed node (continue-on-error, or a node's `record`/`continue` policy), those failures were recorded on `env.Errors` but **silently dropped at serialization** — callers received a success-looking result with no trace of the failure. This was a primary source of "errors not propagating" when building on PetalFlow.

The same DTO also discarded several other envelope fields: `Input`, per-message and per-artifact `Meta`, and trace `ParentID`/`SpanID`.

## Change

- Add an `errors` array to `EnvelopeJSON` (new `NodeErrorJSON` type) and populate it from `env.Errors`. The underlying cause is surfaced as a string only when it adds information beyond the message.
- Print an `Errors` section in the `pretty` CLI output (`formatPretty` previously omitted errors too).
- Complete the wire contract: carry `input`, message/artifact `meta`, and trace `parent_id`/`span_id`.

All additions use `omitempty`, so existing consumers see extra fields only when the data is present — additive and backward compatible.

## Scope / follow-ups

Deliberately **not** in this PR (tracked separately):
- Unifying the two error-handling models (node-level `OnError` vs runtime `ContinueOnError`) — a behavioral change that warrants its own PR.
- A symmetric round-trip constructor (`EnvelopeFromJSON` remains the "raw input -> vars" helper; changing it would break CLI `--input`). Deferred until a consumer needs true round-tripping.

## Testing

- TDD: tests written first and watched fail, then implemented.
- New tests cover: errors surfaced in the struct and in marshaled JSON, `errors` key omitted when empty, message/artifact meta preserved, input preserved, trace parent/span preserved, and pretty-format error surfacing.
- `go build ./...`, `go vet ./...`, and the full `go test ./...` suite pass (23 packages, 0 failures).