### PR TITLE
fix: recover node panics instead of crashing the runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Node panics no longer crash the runtime or daemon.** A panic in any node's
+  `Run` method (including custom `FuncNode`s and tools) is now recovered and
+  converted into a node error that flows through the normal fail /
+  continue-on-error path. Previously an unrecovered panic terminated the whole
+  process, taking down every concurrent run in the daemon; in parallel mode the
+  panic occurred in a worker goroutine the caller could not recover at all.
+  Recovery is applied at the single `executeNode` choke point, so it covers both
+  sequential and parallel execution. Panics are detectable with
+  `errors.Is(err, runtime.ErrNodePanic)`, and the recovered stack trace is
+  attached to the `node.failed` event as `panic_stack`.
+
 ## [0.3.0] - 2026-07-31
 
 ### Added

--- a/runtime/panic_test.go
+++ b/runtime/panic_test.go
@@ -1,0 +1,81 @@
+package runtime_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/petal-labs/petalflow/core"
+	"github.com/petal-labs/petalflow/graph"
+	"github.com/petal-labs/petalflow/runtime"
+)
+
+func TestRuntime_Run_NodePanicReturnsError(t *testing.T) {
+	g := graph.NewGraph("panic-seq")
+	g.AddNode(core.NewFuncNode("boom", func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		panic("kaboom")
+	}))
+	g.SetEntry("boom")
+
+	rt := runtime.NewRuntime()
+
+	_, err := rt.Run(context.Background(), g, core.NewEnvelope(), runtime.DefaultRunOptions())
+	if err == nil {
+		t.Fatal("expected an error from a panicking node, got nil")
+	}
+	if !errors.Is(err, runtime.ErrNodePanic) {
+		t.Errorf("expected error to wrap ErrNodePanic, got %v", err)
+	}
+}
+
+func TestRuntime_Run_NodePanicContinueOnErrorRecordsAndContinues(t *testing.T) {
+	g := graph.NewGraph("panic-continue")
+	g.AddNode(core.NewFuncNode("boom", func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		panic("kaboom")
+	}))
+	g.AddNode(core.NewFuncNode("after", func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		env.SetVar("after_ran", true)
+		return env, nil
+	}))
+	g.AddEdge("boom", "after")
+	g.SetEntry("boom")
+
+	rt := runtime.NewRuntime()
+	opts := runtime.DefaultRunOptions()
+	opts.ContinueOnError = true
+
+	result, err := rt.Run(context.Background(), g, core.NewEnvelope(), opts)
+	if err != nil {
+		t.Fatalf("expected nil error with ContinueOnError, got %v", err)
+	}
+	if !result.HasErrors() {
+		t.Fatal("expected a recorded node error after a panic")
+	}
+	if !strings.Contains(result.Errors[0].Message, "panicked") {
+		t.Errorf("recorded error = %q, want it to mention the panic", result.Errors[0].Message)
+	}
+	if ran, _ := result.GetVar("after_ran"); ran != true {
+		t.Error("expected execution to continue to the next node after a recovered panic")
+	}
+}
+
+func TestRuntime_Run_NodePanicParallelReturnsError(t *testing.T) {
+	g := graph.NewGraph("panic-parallel")
+	g.AddNode(core.NewFuncNode("boom", func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		panic("kaboom")
+	}))
+	g.SetEntry("boom")
+
+	rt := runtime.NewRuntime()
+	opts := runtime.DefaultRunOptions()
+	opts.Concurrency = 2
+
+	_, err := rt.Run(context.Background(), g, core.NewEnvelope(), opts)
+	if err == nil {
+		t.Fatal("expected an error from a panicking node in parallel mode, got nil")
+	}
+	if !errors.Is(err, runtime.ErrNodePanic) {
+		t.Errorf("expected error to wrap ErrNodePanic, got %v", err)
+	}
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -18,7 +19,47 @@ var (
 	ErrMaxHopsExceeded = errors.New("maximum hops exceeded")
 	ErrRunCanceled     = errors.New("run was canceled")
 	ErrNodeExecution   = errors.New("node execution failed")
+	// ErrNodePanic indicates a node's Run method panicked and was recovered.
+	// The panic is converted into an error so it flows through the normal
+	// fail / continue-on-error path instead of crashing the process.
+	ErrNodePanic = errors.New("node panicked")
 )
+
+// NodePanicError is returned when a node's Run method panics. The panic is
+// recovered so it does not crash the runtime (or the daemon hosting it); the
+// recovered value and stack trace are captured for diagnostics. It unwraps to
+// ErrNodePanic so callers can detect panics with errors.Is.
+type NodePanicError struct {
+	NodeID string
+	Value  any
+	Stack  []byte
+}
+
+func (e *NodePanicError) Error() string {
+	return fmt.Sprintf("node %s panicked: %v", e.NodeID, e.Value)
+}
+
+func (e *NodePanicError) Unwrap() error {
+	return ErrNodePanic
+}
+
+// runNodeSafely invokes node.Run, converting any panic into a *NodePanicError.
+// This is the single choke point through which both the sequential path and
+// the parallel workers execute nodes, so recovering here protects every node
+// execution regardless of concurrency.
+func runNodeSafely(ctx context.Context, node core.Node, env *core.Envelope) (result *core.Envelope, err error) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			result = nil
+			err = &NodePanicError{
+				NodeID: node.ID(),
+				Value:  rec,
+				Stack:  debug.Stack(),
+			}
+		}
+	}()
+	return node.Run(ctx, env)
+}
 
 // Runtime executes graphs and emits events.
 type Runtime interface {
@@ -442,7 +483,7 @@ func resolveSequentialNodeOutcome(
 		return result, nil
 	}
 	if !opts.ContinueOnError {
-		return current, fmt.Errorf("%w: node %s: %v", ErrNodeExecution, nodeID, nodeErr)
+		return current, fmt.Errorf("%w: node %s: %w", ErrNodeExecution, nodeID, nodeErr)
 	}
 
 	current.AppendError(core.NodeError{
@@ -730,7 +771,7 @@ func resolveParallelResultEnvelope(
 		return result.envelope, nil
 	}
 	if !opts.ContinueOnError {
-		return nil, fmt.Errorf("%w: node %s: %v", ErrNodeExecution, result.nodeID, result.err)
+		return nil, fmt.Errorf("%w: node %s: %w", ErrNodeExecution, result.nodeID, result.err)
 	}
 
 	node, _ := g.NodeByID(result.nodeID)
@@ -952,18 +993,25 @@ func (r *BasicRuntime) executeNode(
 	// Inject emitter into context for node use
 	nodeCtx := ContextWithEmitter(ctx, emit)
 
-	// Execute node
-	result, err := node.Run(nodeCtx, env)
+	// Execute node with panic recovery so a misbehaving node cannot crash
+	// the runtime (or the daemon hosting it).
+	result, err := runNodeSafely(nodeCtx, node, env)
 
 	// Calculate elapsed time
 	nodeElapsed := opts.Now().Sub(nodeStart)
 
 	if err != nil {
 		// Emit node failed
-		emit(NewEvent(EventNodeFailed, runID).
+		failed := NewEvent(EventNodeFailed, runID).
 			WithNode(nodeID, nodeKind).
 			WithElapsed(nodeElapsed).
-			WithPayload("error", err.Error()))
+			WithPayload("error", err.Error())
+		// Surface the stack trace for panics so operators can diagnose them.
+		var panicErr *NodePanicError
+		if errors.As(err, &panicErr) {
+			failed = failed.WithPayload("panic_stack", string(panicErr.Stack))
+		}
+		emit(failed)
 		return nil, err
 	}
 


### PR DESCRIPTION
## Problem

There was **no `recover()` anywhere** in the runtime. A panic in any node's `Run` method — a nil-map access, an unchecked type assertion, or a bug in a custom `FuncNode`/tool — propagated unrecovered and terminated the whole process. In the long-running daemon that takes down every concurrent run. In parallel mode (`Concurrency > 1`) it was worse: the panic occurred in a worker goroutine the caller cannot recover, so Go terminates the program regardless of the caller's error handling. A single malformed workflow could reliably crash the server.

## Change

- Add `runNodeSafely`, which invokes `node.Run` under `defer/recover` and converts a panic into a typed `*NodePanicError` (unwraps to the new `ErrNodePanic` sentinel, capturing the recovered value and stack).
- Call it from `executeNode` — the single choke point through which **both** the sequential path and the parallel workers run nodes — so all node execution is protected in one place.
- A recovered panic becomes an ordinary node error: it fails the run (default) or is recorded and execution continues (`ContinueOnError`), exactly like any other node error.
- Attach the recovered stack trace to the `node.failed` event as `panic_stack` for diagnostics.
- The two outcome wrappers now use `%w` (not `%v`) on the node error so `errors.Is(err, runtime.ErrNodePanic)` works through the `ErrNodeExecution` wrapper. The rendered error string is unchanged; only the unwrap chain gains detail.

## Testing

- TDD: tests written first and watched fail, then implemented.
- Covers: sequential panic returns an error wrapping `ErrNodePanic` (process survives); `ContinueOnError` records the panic and continues to the next node; parallel-mode panic returns an error without crashing.
- `go build ./...`, `go vet ./...`, `go test -race ./runtime/`, and the full `go test ./...` suite pass (23 packages, 0 failures).

## Note for reviewer

The CHANGELOG adds an `## [Unreleased]` section. PR #138 (surface node errors) also adds one; when both merge there will be a trivial conflict on that shared header — keep both entries under a single `## [Unreleased]`.