### PR TITLE
fix: bound webhook and streaming calls to prevent hangs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   past a failed node returned a success-looking result with no trace of the
   failure. `EnvelopeJSON` now includes an `errors` array, and the `pretty` CLI
   output prints an `Errors` section.
+- **Webhook calls can no longer hang or exhaust memory.** The `webhook_call`
+  node now applies a default 30s timeout when none is configured (previously an
+  unset timeout meant no timeout at all, so a stalled endpoint hung the run),
+  and bounds the response body read with a default 10 MiB limit
+  (`max_response_bytes`), returning an error instead of reading unbounded data.
+- **Streaming LLM calls honor context on a stalled provider.** The Iris
+  streaming adapter and the LLM node's stream consumer now select on
+  `ctx.Done()` while awaiting chunks, so a provider that stalls mid-stream
+  (never sends, never closes the channel) no longer hangs the run or leaks a
+  goroutine; a terminal error chunk is delivered and the stream is closed.
 
 ### Changed
 

--- a/irisadapter/streaming.go
+++ b/irisadapter/streaming.go
@@ -30,43 +30,66 @@ func (a *ProviderAdapter) CompleteStream(ctx context.Context, req petalflow.LLMR
 		var accumulated strings.Builder
 		index := 0
 
-		// Read text deltas from the stream's Ch channel.
-		for chunk := range stream.Ch {
-			accumulated.WriteString(chunk.Delta)
-			sc := petalflow.StreamChunk{
-				Delta:       chunk.Delta,
-				Index:       index,
-				Accumulated: accumulated.String(),
+		// send delivers a delta to out, applying backpressure but never
+		// blocking past cancellation, so a gone consumer cannot leak this
+		// goroutine. It returns false if the context was canceled first.
+		send := func(sc petalflow.StreamChunk) bool {
+			select {
+			case out <- sc:
+				return true
+			case <-ctx.Done():
+				return false
 			}
+		}
+
+		// sendTerminal delivers the final/error chunk. It blocks until the
+		// consumer receives it, but if the context is already canceled it makes
+		// one best-effort non-blocking attempt so the terminal chunk still lands
+		// in the buffered channel (rather than being lost to a random select)
+		// without risking a permanent block when the consumer is gone.
+		sendTerminal := func(sc petalflow.StreamChunk) {
 			select {
 			case out <- sc:
 			case <-ctx.Done():
-				out <- petalflow.StreamChunk{
-					Error: ctx.Err(),
-					Done:  true,
+				select {
+				case out <- sc:
+				default:
 				}
-				return
 			}
-			index++
 		}
 
-		// Check if context was canceled while reading chunks.
-		if ctx.Err() != nil {
-			out <- petalflow.StreamChunk{
-				Error: ctx.Err(),
-				Done:  true,
+		// Read text deltas from the stream's Ch channel. The receive selects on
+		// ctx.Done() so a provider that stalls (never sends, never closes Ch)
+		// cannot hang this goroutine.
+		streaming := true
+		for streaming {
+			select {
+			case <-ctx.Done():
+				sendTerminal(petalflow.StreamChunk{Error: ctx.Err(), Done: true})
+				return
+			case chunk, ok := <-stream.Ch:
+				if !ok {
+					streaming = false
+					break
+				}
+				accumulated.WriteString(chunk.Delta)
+				if !send(petalflow.StreamChunk{
+					Delta:       chunk.Delta,
+					Index:       index,
+					Accumulated: accumulated.String(),
+				}) {
+					sendTerminal(petalflow.StreamChunk{Error: ctx.Err(), Done: true})
+					return
+				}
+				index++
 			}
-			return
 		}
 
 		// Check for streaming errors.
 		select {
 		case err, ok := <-stream.Err:
 			if ok && err != nil {
-				out <- petalflow.StreamChunk{
-					Error: err,
-					Done:  true,
-				}
+				sendTerminal(petalflow.StreamChunk{Error: err, Done: true})
 				return
 			}
 		default:
@@ -91,7 +114,7 @@ func (a *ProviderAdapter) CompleteStream(ctx context.Context, req petalflow.LLMR
 			finalChunk.Error = ctx.Err()
 		}
 
-		out <- finalChunk
+		sendTerminal(finalChunk)
 	}()
 
 	return out, nil

--- a/irisadapter/streaming_test.go
+++ b/irisadapter/streaming_test.go
@@ -325,6 +325,50 @@ func TestProviderAdapter_CompleteStream_ContextCancellation(t *testing.T) {
 	}
 }
 
+func TestProviderAdapter_CompleteStream_StalledProviderHonorsContext(t *testing.T) {
+	// Provider returns a stream that never sends a chunk and never closes its
+	// channels, simulating a provider that stalls mid-stream and ignores ctx.
+	mock := &streamingMockProvider{
+		mockProvider: mockProvider{id: "mock"},
+		streamFn: func(ctx context.Context, req *core.ChatRequest) (*core.ChatStream, error) {
+			return &core.ChatStream{
+				Ch:    make(chan core.ChatChunk),     // never sent to, never closed
+				Err:   make(chan error),              // never closed
+				Final: make(chan *core.ChatResponse), // never closed
+			}, nil
+		},
+	}
+
+	adapter := NewProviderAdapter(mock)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	ch, err := adapter.CompleteStream(ctx, petalflow.LLMRequest{
+		Model:     "mock-model",
+		InputText: "Hello",
+	})
+	if err != nil {
+		t.Fatalf("unexpected setup error: %v", err)
+	}
+
+	// The adapter must emit a terminal error chunk and close its output channel
+	// once the context is canceled, even though the provider never closes its
+	// stream. Bound the wait so a regression (infinite hang) fails the test
+	// instead of hanging forever.
+	select {
+	case chunk, ok := <-ch:
+		if !ok {
+			t.Fatal("expected a terminal chunk before the channel closed")
+		}
+		if chunk.Error == nil {
+			t.Errorf("expected a context error chunk, got %+v", chunk)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("CompleteStream did not honor context cancellation with a stalled provider")
+	}
+}
+
 func TestProviderAdapter_CompleteStream_NoFinalResponse(t *testing.T) {
 	mock := &streamingMockProvider{
 		mockProvider: mockProvider{id: "mock"},

--- a/nodes/llm.go
+++ b/nodes/llm.go
@@ -226,28 +226,42 @@ func (n *LLMNode) runStreaming(ctx context.Context, env *core.Envelope, streamCl
 	var accumulated strings.Builder
 	var usage core.LLMTokenUsage
 
-	for chunk := range ch {
-		// Handle chunk errors
-		if chunk.Error != nil {
-			return nil, fmt.Errorf("streaming error: %w", chunk.Error)
-		}
-
-		if chunk.Done {
-			// Capture usage from the final chunk
-			if chunk.Usage != nil {
-				usage = *chunk.Usage
+	streaming := true
+	for streaming {
+		// Select on ctx.Done() so a client that stalls (never sends, never
+		// closes the channel) cannot hang the node past its timeout/cancel.
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case chunk, ok := <-ch:
+			if !ok {
+				streaming = false
+				break
 			}
-			break
+
+			// Handle chunk errors
+			if chunk.Error != nil {
+				return nil, fmt.Errorf("streaming error: %w", chunk.Error)
+			}
+
+			if chunk.Done {
+				// Capture usage from the final chunk
+				if chunk.Usage != nil {
+					usage = *chunk.Usage
+				}
+				streaming = false
+				break
+			}
+
+			// Accumulate text
+			accumulated.WriteString(chunk.Delta)
+
+			// Emit delta event
+			emit(runtime.NewEvent(runtime.EventNodeOutputDelta, env.Trace.RunID).
+				WithNode(n.ID(), n.Kind()).
+				WithPayload("delta", chunk.Delta).
+				WithPayload("index", chunk.Index))
 		}
-
-		// Accumulate text
-		accumulated.WriteString(chunk.Delta)
-
-		// Emit delta event
-		emit(runtime.NewEvent(runtime.EventNodeOutputDelta, env.Trace.RunID).
-			WithNode(n.ID(), n.Kind()).
-			WithPayload("delta", chunk.Delta).
-			WithPayload("index", chunk.Index))
 	}
 
 	text := accumulated.String()

--- a/nodes/llm_test.go
+++ b/nodes/llm_test.go
@@ -408,6 +408,44 @@ func (m *mockStreamingLLMClient) CompleteStream(ctx context.Context, req core.LL
 	return ch, nil
 }
 
+// stallingStreamingLLMClient returns a stream that never sends and never
+// closes, simulating a streaming client that stalls and ignores context.
+type stallingStreamingLLMClient struct{}
+
+func (m *stallingStreamingLLMClient) Complete(ctx context.Context, req core.LLMRequest) (core.LLMResponse, error) {
+	return core.LLMResponse{}, nil
+}
+
+func (m *stallingStreamingLLMClient) CompleteStream(ctx context.Context, req core.LLMRequest) (<-chan core.StreamChunk, error) {
+	return make(chan core.StreamChunk), nil // never sent to, never closed
+}
+
+func TestLLMNode_Run_StreamingStallHonorsContext(t *testing.T) {
+	node := NewLLMNode("test-llm", &stallingStreamingLLMClient{}, LLMNodeConfig{
+		Model:     "gpt-4",
+		OutputKey: "answer",
+		Timeout:   50 * time.Millisecond,
+	})
+
+	env := core.NewEnvelope()
+	env.Trace.RunID = "test-run"
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := node.Run(context.Background(), env)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected a context error from a stalled stream, got nil")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("LLMNode.Run did not return when the streaming client stalled")
+	}
+}
+
 func TestLLMNode_Run_Streaming(t *testing.T) {
 	client := &mockStreamingLLMClient{
 		chunks: []core.StreamChunk{

--- a/nodes/webhook_call.go
+++ b/nodes/webhook_call.go
@@ -28,12 +28,22 @@ const (
 	WebhookCallErrorPolicyRecord   WebhookCallErrorPolicy = "record"
 )
 
+// defaultWebhookTimeout bounds an outbound webhook call when no timeout is
+// configured, so a stalled endpoint cannot hang a run indefinitely.
+const defaultWebhookTimeout = 30 * time.Second
+
+// defaultWebhookMaxResponseBytes caps how much of a webhook response body is
+// read when no limit is configured, protecting against unbounded/hostile
+// responses exhausting memory.
+const defaultWebhookMaxResponseBytes int64 = 10 << 20 // 10 MiB
+
 // WebhookCallNodeConfig configures a WebhookCallNode.
 type WebhookCallNodeConfig struct {
 	URL              string
 	Method           string
 	Headers          map[string]string
 	Timeout          time.Duration
+	MaxResponseBytes int64
 	InputVars        []string
 	IncludeArtifacts bool
 	IncludeMessages  bool
@@ -47,12 +57,13 @@ type WebhookCallNodeConfig struct {
 // ParseWebhookCallConfig normalizes webhook_call config from graph JSON.
 func ParseWebhookCallConfig(m map[string]any) (WebhookCallNodeConfig, error) {
 	cfg := WebhookCallNodeConfig{
-		URL:         strings.TrimSpace(webhookConfigString(m, "url")),
-		Method:      strings.TrimSpace(webhookConfigString(m, "method")),
-		Template:    webhookConfigString(m, "template"),
-		ResultVar:   strings.TrimSpace(webhookConfigString(m, "result_var")),
-		ErrorPolicy: WebhookCallErrorPolicy(strings.TrimSpace(webhookConfigString(m, "error_policy"))),
-		Timeout:     webhookConfigDuration(m, "timeout"),
+		URL:              strings.TrimSpace(webhookConfigString(m, "url")),
+		Method:           strings.TrimSpace(webhookConfigString(m, "method")),
+		Template:         webhookConfigString(m, "template"),
+		ResultVar:        strings.TrimSpace(webhookConfigString(m, "result_var")),
+		ErrorPolicy:      WebhookCallErrorPolicy(strings.TrimSpace(webhookConfigString(m, "error_policy"))),
+		Timeout:          webhookConfigDuration(m, "timeout"),
+		MaxResponseBytes: webhookConfigInt64(m, "max_response_bytes"),
 	}
 	if inputVars, ok := webhookConfigStringSlice(m, "input_vars"); ok {
 		cfg.InputVars = inputVars
@@ -101,6 +112,12 @@ func normalizeWebhookCallConfig(cfg WebhookCallNodeConfig) (WebhookCallNodeConfi
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = http.DefaultClient
 	}
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultWebhookTimeout
+	}
+	if cfg.MaxResponseBytes <= 0 {
+		cfg.MaxResponseBytes = defaultWebhookMaxResponseBytes
+	}
 	if len(cfg.Headers) == 0 {
 		cfg.Headers = nil
 	}
@@ -126,6 +143,12 @@ func NewWebhookCallNode(id string, config WebhookCallNodeConfig) *WebhookCallNod
 		}
 		if normalized.ErrorPolicy == "" {
 			normalized.ErrorPolicy = WebhookCallErrorPolicyFail
+		}
+		if normalized.Timeout <= 0 {
+			normalized.Timeout = defaultWebhookTimeout
+		}
+		if normalized.MaxResponseBytes <= 0 {
+			normalized.MaxResponseBytes = defaultWebhookMaxResponseBytes
 		}
 	}
 
@@ -175,9 +198,19 @@ func (n *WebhookCallNode) Run(ctx context.Context, env *core.Envelope) (*core.En
 	}
 	defer resp.Body.Close()
 
-	respBody, readErr := io.ReadAll(resp.Body)
+	limit := n.config.MaxResponseBytes
+	if limit <= 0 {
+		limit = defaultWebhookMaxResponseBytes
+	}
+	// Read one byte past the limit so we can detect an oversized body rather
+	// than silently truncating it.
+	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, limit+1))
 	if readErr != nil {
 		return n.handleFailure(env, resp.StatusCode, resp.Header, nil, fmt.Errorf("read response body: %w", readErr))
+	}
+	if int64(len(respBody)) > limit {
+		return n.handleFailure(env, resp.StatusCode, resp.Header, nil,
+			fmt.Errorf("response body exceeds max %d bytes", limit))
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {

--- a/nodes/webhook_call_test.go
+++ b/nodes/webhook_call_test.go
@@ -186,6 +186,54 @@ func TestWebhookCallNode_InvalidPolicy(t *testing.T) {
 	}
 }
 
+func TestWebhookCallNode_AppliesDefaultTimeout(t *testing.T) {
+	cfg, err := ParseWebhookCallConfig(map[string]any{
+		"url": "https://example.com/webhook",
+	})
+	if err != nil {
+		t.Fatalf("ParseWebhookCallConfig() error = %v", err)
+	}
+	if cfg.Timeout <= 0 {
+		t.Errorf("expected a positive default timeout, got %v", cfg.Timeout)
+	}
+}
+
+func TestWebhookCallNode_PreservesExplicitTimeout(t *testing.T) {
+	cfg, err := ParseWebhookCallConfig(map[string]any{
+		"url":     "https://example.com/webhook",
+		"timeout": "5s",
+	})
+	if err != nil {
+		t.Fatalf("ParseWebhookCallConfig() error = %v", err)
+	}
+	if cfg.Timeout != 5*time.Second {
+		t.Errorf("Timeout = %v, want 5s", cfg.Timeout)
+	}
+}
+
+func TestWebhookCallNode_RejectsOversizeResponse(t *testing.T) {
+	node := NewWebhookCallNode("call", WebhookCallNodeConfig{
+		URL:              "https://example.com/webhook",
+		MaxResponseBytes: 8,
+		ErrorPolicy:      WebhookCallErrorPolicyFail,
+		HTTPClient: &MockHTTPClient{
+			Response: &http.Response{
+				StatusCode: 200,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader("0123456789ABCDEF")), // 16 bytes
+			},
+		},
+	})
+
+	_, err := node.Run(context.Background(), core.NewEnvelope())
+	if err == nil {
+		t.Fatal("expected error for oversize response body, got nil")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("error = %v, want it to mention the size limit", err)
+	}
+}
+
 func TestWebhookCallNode_ConfigDefaults(t *testing.T) {
 	cfg, err := ParseWebhookCallConfig(map[string]any{
 		"url": "https://example.com/webhook",

--- a/nodes/webhook_config_helpers.go
+++ b/nodes/webhook_config_helpers.go
@@ -27,6 +27,19 @@ func webhookConfigStringSlice(m map[string]any, key string) ([]string, bool) {
 	return out, true
 }
 
+func webhookConfigInt64(m map[string]any, key string) int64 {
+	switch v := m[key].(type) {
+	case float64:
+		return int64(v)
+	case int64:
+		return v
+	case int:
+		return int64(v)
+	default:
+		return 0
+	}
+}
+
 func webhookConfigDuration(m map[string]any, key string) time.Duration {
 	switch v := m[key].(type) {
 	case string:


### PR DESCRIPTION
Part of the timeout cluster (P0-4 + P0-5). Two node/adapter gaps that could hang a run indefinitely.

## P0-4 — webhook_call node

- **No default timeout.** The node applied `context.WithTimeout` only when `Timeout > 0`, with no default, and fell back to `http.DefaultClient` (which has no client timeout). An unconfigured webhook to a server that accepts but never responds hung the run forever. Now defaults to **30s** (matching the tool node), applied in both `normalizeWebhookCallConfig` and the `NewWebhookCallNode` fallback path.
- **Unbounded response read.** `io.ReadAll(resp.Body)` could OOM on a hostile/huge response. Now bounded by `MaxResponseBytes` (default **10 MiB**, settable via `max_response_bytes` in graph JSON); an oversized body returns an error instead of being silently truncated.

## P0-5 — streaming stall

- The Iris streaming adapter read provider chunks with `for chunk := range stream.Ch`, observing `ctx` only while *sending* downstream. A provider that stalled mid-stream (never sends, never closes `Ch`) parked the goroutine past the node timeout and leaked it. The read now selects on `ctx.Done()`, emits a terminal error chunk, and closes the stream.
- The LLM node's consumer (`for chunk := range ch`) had the same defect and trusted the client to close the channel; it now selects on `ctx.Done()` too (defense against any `StreamingLLMClient`).
- Terminal chunk delivery uses a blocking send with a **non-blocking fallback after cancel**, so the terminal chunk still lands in the buffered channel (instead of being lost to a random `select` when ctx is already done) without risking a permanent block when the consumer is gone. This fixed a `-race`-only flake found during development.

## Testing

- TDD throughout; each test written and watched fail first. New coverage: webhook default timeout applied / explicit preserved / oversized response rejected; adapter honors ctx with a stalled provider that never closes its channels; LLM node returns when a streaming client stalls.
- Both modules verified: main module `go build/vet/test` (23 packages, 0 failures); `irisadapter` module `go build/vet` and `go test -race -count=10` clean.

## Note for reviewer

CHANGELOG adds entries under the existing `## [Unreleased]` section (already on main from #138/#139), so no conflict expected this time.

Follow-up in this cluster: **P0-3** (make the runtime able to interrupt a ctx-ignoring node; nodes will run on a cloned envelope) and **P1-7** (server `WriteTimeout` vs SSE, `ReadHeaderTimeout`/`IdleTimeout`, handler goroutine leak).