### PR TITLE
feat: add per-node timeout to interrupt stuck nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (never sends, never closes the channel) no longer hangs the run or leaks a
   goroutine; a terminal error chunk is delivered and the stream is closed.
 
+### Added
+
+- **Per-node timeout (`RunOptions.NodeTimeout`, CLI `--node-timeout`).** When
+  set, each node runs with a deadline and the runtime returns as soon as the
+  deadline or the parent context fires, even if the node itself ignores
+  cancellation. Previously a node that ignored its context could hang a run
+  indefinitely — the run-level timeout could never fire because the node call
+  never returned. Nodes run on a cloned envelope so a node abandoned on timeout
+  cannot corrupt the envelope the caller proceeds with. Defaults to 0 (disabled),
+  preserving the original inline execution when unset.
+
 ### Changed
 
 - **Completed the `EnvelopeJSON` wire contract.** Added `input`, per-message and

--- a/cli/run.go
+++ b/cli/run.go
@@ -47,6 +47,7 @@ func NewRunCmd() *cobra.Command {
 	cmd.Flags().StringP("output", "o", "", "Write output envelope to file (default: stdout)")
 	cmd.Flags().String("format", "pretty", "Output format: json | text | pretty")
 	cmd.Flags().Duration("timeout", 5*time.Minute, "Execution timeout")
+	cmd.Flags().Duration("node-timeout", 0, "Per-node timeout; interrupts a node that ignores cancellation (0 = disabled)")
 	cmd.Flags().Bool("dry-run", false, "Compile and validate only, do not execute")
 	cmd.Flags().StringArray("env", nil, "Set environment variable (repeatable)")
 	cmd.Flags().StringArray("provider-key", nil, "Set provider API key (repeatable, e.g. --provider-key anthropic=sk-...)")
@@ -234,6 +235,7 @@ func runContext(cmd *cobra.Command) (context.Context, context.CancelFunc, time.D
 
 func buildRunOptions(cmd *cobra.Command) (runtime.RunOptions, bool) {
 	opts := runtime.DefaultRunOptions()
+	opts.NodeTimeout, _ = cmd.Flags().GetDuration("node-timeout")
 	streaming, _ := cmd.Flags().GetBool("stream")
 	if streaming {
 		opts.EventHandler = runStreamingEventHandler(cmd.OutOrStdout())

--- a/cli/run_internal_test.go
+++ b/cli/run_internal_test.go
@@ -77,6 +77,27 @@ func TestBuildRunOptions_StreamingHandler(t *testing.T) {
 	}
 }
 
+func TestBuildRunOptions_NodeTimeout(t *testing.T) {
+	cmd := NewRunCmd()
+	if err := cmd.Flags().Set("node-timeout", "5s"); err != nil {
+		t.Fatalf("setting node-timeout flag: %v", err)
+	}
+
+	opts, _ := buildRunOptions(cmd)
+	if opts.NodeTimeout != 5*time.Second {
+		t.Errorf("NodeTimeout = %v, want 5s", opts.NodeTimeout)
+	}
+}
+
+func TestBuildRunOptions_NodeTimeoutDefaultDisabled(t *testing.T) {
+	cmd := NewRunCmd()
+
+	opts, _ := buildRunOptions(cmd)
+	if opts.NodeTimeout != 0 {
+		t.Errorf("NodeTimeout default = %v, want 0 (disabled)", opts.NodeTimeout)
+	}
+}
+
 func TestApplyRunEnvVars(t *testing.T) {
 	cmd := NewRunCmd()
 	key := "PETALFLOW_RUN_ENV_TEST"

--- a/runtime/node_timeout_test.go
+++ b/runtime/node_timeout_test.go
@@ -1,0 +1,139 @@
+package runtime_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/petalflow/core"
+	"github.com/petal-labs/petalflow/graph"
+	"github.com/petal-labs/petalflow/runtime"
+)
+
+// blockingNode ignores its context and sleeps, simulating a node that does not
+// honor cancellation.
+func blockingNode(id string, d time.Duration) core.Node {
+	return core.NewFuncNode(id, func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		time.Sleep(d)
+		return env, nil
+	})
+}
+
+func TestRuntime_Run_NodeTimeoutInterruptsBlockingNode(t *testing.T) {
+	g := graph.NewGraph("blocking")
+	g.AddNode(blockingNode("block", 30*time.Second))
+	g.SetEntry("block")
+
+	rt := runtime.NewRuntime()
+	opts := runtime.DefaultRunOptions()
+	opts.NodeTimeout = 50 * time.Millisecond
+
+	done := make(chan error, 1)
+	start := time.Now()
+	go func() {
+		_, err := rt.Run(context.Background(), g, core.NewEnvelope(), opts)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected a node timeout error, got nil")
+		}
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Errorf("expected error to wrap context.DeadlineExceeded, got %v", err)
+		}
+		if elapsed := time.Since(start); elapsed > time.Second {
+			t.Errorf("run took %v, expected prompt return under NodeTimeout", elapsed)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return under NodeTimeout with a blocking node")
+	}
+}
+
+func TestRuntime_Run_NodeTimeoutHonorsParentCancel(t *testing.T) {
+	started := make(chan struct{})
+	g := graph.NewGraph("cancel")
+	g.AddNode(core.NewFuncNode("block", func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		close(started)
+		time.Sleep(30 * time.Second) // ignores ctx
+		return env, nil
+	}))
+	g.SetEntry("block")
+
+	rt := runtime.NewRuntime()
+	opts := runtime.DefaultRunOptions()
+	opts.NodeTimeout = 30 * time.Second // large; parent cancel should win
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := rt.Run(ctx, g, core.NewEnvelope(), opts)
+		done <- err
+	}()
+
+	<-started
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("expected an error after parent cancel, got nil")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return after parent context was canceled")
+	}
+}
+
+func TestRuntime_Run_NodeTimeoutIsolatesAbandonedWrites(t *testing.T) {
+	release := make(chan struct{})
+	wrote := make(chan struct{})
+	g := graph.NewGraph("abandon")
+	g.AddNode(core.NewFuncNode("slow", func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		<-release // do not write until the test allows it (after the run returns)
+		env.SetVar("late", "written-after-timeout")
+		close(wrote)
+		return env, nil
+	}))
+	g.SetEntry("slow")
+
+	rt := runtime.NewRuntime()
+	opts := runtime.DefaultRunOptions()
+	opts.NodeTimeout = 30 * time.Millisecond
+
+	inputEnv := core.NewEnvelope()
+	_, err := rt.Run(context.Background(), g, inputEnv, opts)
+	if err == nil {
+		t.Fatal("expected a node timeout error, got nil")
+	}
+
+	// Let the abandoned node proceed; it should write to its own clone.
+	close(release)
+	<-wrote
+
+	if _, ok := inputEnv.GetVar("late"); ok {
+		t.Error("abandoned node write leaked into the caller's envelope; clone isolation failed")
+	}
+}
+
+func TestRuntime_Run_NodeTimeoutFastNodeSucceeds(t *testing.T) {
+	g := graph.NewGraph("fast")
+	g.AddNode(core.NewFuncNode("quick", func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		env.SetVar("done", true)
+		return env, nil
+	}))
+	g.SetEntry("quick")
+
+	rt := runtime.NewRuntime()
+	opts := runtime.DefaultRunOptions()
+	opts.NodeTimeout = 2 * time.Second
+
+	result, err := rt.Run(context.Background(), g, core.NewEnvelope(), opts)
+	if err != nil {
+		t.Fatalf("unexpected error for a fast node under NodeTimeout: %v", err)
+	}
+	if v, ok := result.GetVar("done"); !ok || v != true {
+		t.Error("expected the fast node's output to be adopted")
+	}
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -61,6 +61,36 @@ func runNodeSafely(ctx context.Context, node core.Node, env *core.Envelope) (res
 	return node.Run(ctx, env)
 }
 
+// runNodeInterruptible runs a node under a context that may be canceled (via a
+// per-node timeout or parent cancellation) and returns as soon as ctx fires,
+// even if the node itself ignores cancellation.
+//
+// The node runs on a clone of the envelope so that a node abandoned on
+// timeout — one that keeps running after we return — mutates its own copy
+// rather than the envelope the caller continues with. Top-level Vars are fully
+// isolated because Clone allocates a fresh map; deep isolation of nested values
+// is completed by the Clone deep-copy fix tracked separately.
+func runNodeInterruptible(ctx context.Context, node core.Node, env *core.Envelope) (*core.Envelope, error) {
+	type outcome struct {
+		env *core.Envelope
+		err error
+	}
+	done := make(chan outcome, 1)
+
+	branch := env.Clone()
+	go func() {
+		res, runErr := runNodeSafely(ctx, node, branch)
+		done <- outcome{env: res, err: runErr}
+	}()
+
+	select {
+	case oc := <-done:
+		return oc.env, oc.err
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}
+
 // Runtime executes graphs and emits events.
 type Runtime interface {
 	// Run executes the graph with the given initial envelope.
@@ -81,6 +111,13 @@ type RunOptions struct {
 
 	// Concurrency sets the worker pool size for parallel execution (default: 1).
 	Concurrency int
+
+	// NodeTimeout bounds how long a single node may run. When > 0, each node
+	// executes on a goroutine with this deadline and the runtime returns as soon
+	// as the deadline (or the parent context) fires, even if the node itself
+	// ignores cancellation. When 0 (the default) nodes run inline with no
+	// runtime-imposed per-node deadline, preserving the original behavior.
+	NodeTimeout time.Duration
 
 	// Now provides the current time (for testing). If nil, uses time.Now.
 	Now func() time.Time
@@ -994,8 +1031,18 @@ func (r *BasicRuntime) executeNode(
 	nodeCtx := ContextWithEmitter(ctx, emit)
 
 	// Execute node with panic recovery so a misbehaving node cannot crash
-	// the runtime (or the daemon hosting it).
-	result, err := runNodeSafely(nodeCtx, node, env)
+	// the runtime (or the daemon hosting it). When a per-node timeout is
+	// configured, run the node interruptibly so it cannot hang the run.
+	var result *core.Envelope
+	var err error
+	if opts.NodeTimeout > 0 {
+		var cancel context.CancelFunc
+		nodeCtx, cancel = context.WithTimeout(nodeCtx, opts.NodeTimeout)
+		defer cancel()
+		result, err = runNodeInterruptible(nodeCtx, node, env)
+	} else {
+		result, err = runNodeSafely(nodeCtx, node, env)
+	}
 
 	// Calculate elapsed time
 	nodeElapsed := opts.Now().Sub(nodeStart)


### PR DESCRIPTION
Part of the timeout cluster (P0-3), the root cause the other timeout fixes compound on.

## Problem

The runtime executed each node inline (`runNodeSafely(nodeCtx, node, env)`) and only checked the context *between* nodes. So a node that ignores cancellation — a custom `FuncNode`, a stalled dependency, a tight loop — could hang a run forever. Critically, the **run-level timeout could never fire** because `rt.Run` never returned; and in parallel mode `stopWorkers()` blocked on `wg.Wait()` for a worker stuck in `node.Run`. This is the deepest of the reported "timeouts" problems.

## Change

- Add `RunOptions.NodeTimeout time.Duration` and a CLI `--node-timeout` flag.
- When `NodeTimeout > 0`, `executeNode` applies a per-node deadline context and runs the node via `runNodeInterruptible`: the node runs on a goroutine and the runtime `select`s on node completion vs `ctx.Done()`. On timeout/parent-cancel it returns `ctx.Err()` promptly (wrapped through `ErrNodeExecution`, so `errors.Is(err, context.DeadlineExceeded)` / `context.Canceled` work). This is applied at the single `executeNode` choke point, so it covers both sequential and parallel execution.
- The node runs on `env.Clone()`, so a node abandoned on timeout mutates its own copy rather than the envelope the caller proceeds with. Panic recovery (`runNodeSafely`) still applies inside the goroutine.
- `NodeTimeout` defaults to **0 (disabled)** — when unset, nodes run inline exactly as before (`ctx.Done() == nil` fast path avoided entirely), so existing behavior and tests are unchanged.

## Scope / follow-ups

- **Deep clone (P1-5):** top-level `Vars` are fully isolated because `Clone` allocates a fresh map. Nested map/slice values remain shared until the `Clone` deep-copy fix (next planned PR), which completes the abandonment-isolation guarantee. Called out in the code comment.
- **Daemon wiring:** this PR exposes `NodeTimeout` via the library (`RunOptions`) and the CLI. Wiring a daemon/server default is a small follow-up (more config surface).

## Testing

- TDD throughout; each test written and watched fail first. Coverage: `NodeTimeout` interrupts a node that sleeps 30s ignoring ctx (returns in <1s wrapping `DeadlineExceeded`); parent-cancel is honored when `NodeTimeout` is large; an abandoned node's post-timeout write does not leak into the caller's envelope (clone isolation); a fast node under `NodeTimeout` still succeeds; CLI `--node-timeout` sets the option and defaults to disabled.
- `go build/vet/test ./...` green (23 packages, 0 failures); `go test -race -count=5 ./runtime/...` clean.