### PR TITLE
fix: deep-copy nested state in Envelope.Clone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ctx.Done()` while awaiting chunks, so a provider that stalls mid-stream
   (never sends, never closes the channel) no longer hangs the run or leaks a
   goroutine; a terminal error chunk is delivered and the stream is closed.
-
-### Added
+- **`Envelope.Clone()` now deep-copies nested state.** Clone previously
+  shallow-copied `Vars` values and the `Meta`/`Bytes`/`Details` fields of
+  artifacts, messages, and node errors, so parallel branches (and nodes
+  abandoned on timeout) shared backing maps and slices — a latent data race and
+  cross-branch corruption. Clone now deep-copies JSON-like values
+  (`map[string]any`, `[]any`, `[]byte`) throughout, giving each branch fully
+  independent state. This completes the abandoned-node isolation added with
+  `NodeTimeout`. `Input` and non-JSON-like values remain copied by reference and
+  must be treated as read-only across branches.
 
 - **Per-node timeout (`RunOptions.NodeTimeout`, CLI `--node-timeout`).** When
   set, each node runs with a deadline and the runtime returns as soon as the

--- a/core/envelope.go
+++ b/core/envelope.go
@@ -47,8 +47,16 @@ func NewEnvelope() *Envelope {
 }
 
 // Clone creates a copy of the envelope suitable for parallel execution.
-// Maps and slices are shallow-copied to avoid accidental cross-branch mutation.
-// Note: payload fields inside Artifacts and Messages may still reference shared memory.
+//
+// Vars, Artifacts, Messages, and Errors are deep-copied so that mutations in
+// one branch (or a node abandoned on timeout) cannot affect another branch or
+// the caller. Deep copying covers JSON-like values — nested map[string]any,
+// []any, and []byte — as well as the Meta/Bytes/Details fields of Artifacts,
+// Messages, and NodeErrors.
+//
+// Input and any non-JSON-like values inside Vars (arbitrary structs, pointers,
+// channels, etc.) are copied by reference, since they cannot be deep-copied
+// generically; callers must treat such values as read-only across branches.
 func (e *Envelope) Clone() *Envelope {
 	if e == nil {
 		return nil
@@ -59,31 +67,84 @@ func (e *Envelope) Clone() *Envelope {
 		Trace: e.Trace,
 	}
 
-	// Deep copy Vars map
-	if e.Vars != nil {
-		out.Vars = make(map[string]any, len(e.Vars))
-		for k, v := range e.Vars {
-			out.Vars[k] = v
-		}
-	}
+	out.Vars = deepCopyStringMap(e.Vars)
 
-	// Copy slices
 	if e.Artifacts != nil {
 		out.Artifacts = make([]Artifact, len(e.Artifacts))
-		copy(out.Artifacts, e.Artifacts)
+		for i, a := range e.Artifacts {
+			out.Artifacts[i] = cloneArtifact(a)
+		}
 	}
 
 	if e.Messages != nil {
 		out.Messages = make([]Message, len(e.Messages))
-		copy(out.Messages, e.Messages)
+		for i, m := range e.Messages {
+			out.Messages[i] = cloneMessage(m)
+		}
 	}
 
 	if e.Errors != nil {
 		out.Errors = make([]NodeError, len(e.Errors))
-		copy(out.Errors, e.Errors)
+		for i, ne := range e.Errors {
+			out.Errors[i] = cloneNodeError(ne)
+		}
 	}
 
 	return out
+}
+
+// deepCopyValue returns a deep copy of JSON-like values (map[string]any, []any,
+// and []byte). Scalars and unrecognized types are returned as-is, since
+// PetalFlow cannot generically deep-copy arbitrary Go values.
+func deepCopyValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		return deepCopyStringMap(val)
+	case []any:
+		out := make([]any, len(val))
+		for i, item := range val {
+			out[i] = deepCopyValue(item)
+		}
+		return out
+	case []byte:
+		return append([]byte(nil), val...)
+	default:
+		return v
+	}
+}
+
+// deepCopyStringMap returns a deep copy of a map[string]any, preserving nil.
+func deepCopyStringMap(m map[string]any) map[string]any {
+	if m == nil {
+		return nil
+	}
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = deepCopyValue(v)
+	}
+	return out
+}
+
+// cloneArtifact returns a copy of a with its Meta map and Bytes slice deep-copied.
+func cloneArtifact(a Artifact) Artifact {
+	a.Meta = deepCopyStringMap(a.Meta)
+	if a.Bytes != nil {
+		a.Bytes = append([]byte(nil), a.Bytes...)
+	}
+	return a
+}
+
+// cloneMessage returns a copy of m with its Meta map deep-copied.
+func cloneMessage(m Message) Message {
+	m.Meta = deepCopyStringMap(m.Meta)
+	return m
+}
+
+// cloneNodeError returns a copy of ne with its Details map deep-copied. The
+// Cause error is shared, as errors are treated as immutable.
+func cloneNodeError(ne NodeError) NodeError {
+	ne.Details = deepCopyStringMap(ne.Details)
+	return ne
 }
 
 // GetVar retrieves a variable by name from the Vars map.

--- a/core/envelope_test.go
+++ b/core/envelope_test.go
@@ -64,6 +64,78 @@ func TestEnvelope_Clone(t *testing.T) {
 	}
 }
 
+func TestEnvelope_Clone_DeepCopiesNestedVarMap(t *testing.T) {
+	original := NewEnvelope()
+	original.SetVar("nested", map[string]any{"k": "original"})
+
+	clone := original.Clone()
+	clone.Vars["nested"].(map[string]any)["k"] = "changed"
+
+	if got := original.Vars["nested"].(map[string]any)["k"]; got != "original" {
+		t.Errorf("nested var = %q, want %q (clone shared the nested map)", got, "original")
+	}
+}
+
+func TestEnvelope_Clone_DeepCopiesNestedVarSlice(t *testing.T) {
+	original := NewEnvelope()
+	original.SetVar("list", []any{"a", "b"})
+
+	clone := original.Clone()
+	clone.Vars["list"].([]any)[0] = "z"
+
+	if got := original.Vars["list"].([]any)[0]; got != "a" {
+		t.Errorf("nested slice element = %q, want %q (clone shared the backing array)", got, "a")
+	}
+}
+
+func TestEnvelope_Clone_DeepCopiesArtifactMeta(t *testing.T) {
+	original := NewEnvelope()
+	original.AppendArtifact(Artifact{ID: "a1", Meta: map[string]any{"score": 1}})
+
+	clone := original.Clone()
+	clone.Artifacts[0].Meta["score"] = 2
+
+	if got := original.Artifacts[0].Meta["score"]; got != 1 {
+		t.Errorf("artifact meta = %v, want 1 (clone shared the Meta map)", got)
+	}
+}
+
+func TestEnvelope_Clone_DeepCopiesArtifactBytes(t *testing.T) {
+	original := NewEnvelope()
+	original.AppendArtifact(Artifact{ID: "a1", Bytes: []byte{1, 2, 3}})
+
+	clone := original.Clone()
+	clone.Artifacts[0].Bytes[0] = 9
+
+	if got := original.Artifacts[0].Bytes[0]; got != 1 {
+		t.Errorf("artifact bytes[0] = %d, want 1 (clone shared the backing array)", got)
+	}
+}
+
+func TestEnvelope_Clone_DeepCopiesMessageMeta(t *testing.T) {
+	original := NewEnvelope()
+	original.AppendMessage(Message{Role: "assistant", Content: "hi", Meta: map[string]any{"model": "x"}})
+
+	clone := original.Clone()
+	clone.Messages[0].Meta["model"] = "y"
+
+	if got := original.Messages[0].Meta["model"]; got != "x" {
+		t.Errorf("message meta = %v, want x (clone shared the Meta map)", got)
+	}
+}
+
+func TestEnvelope_Clone_DeepCopiesNodeErrorDetails(t *testing.T) {
+	original := NewEnvelope()
+	original.AppendError(NodeError{NodeID: "n1", Details: map[string]any{"attempt": 1}})
+
+	clone := original.Clone()
+	clone.Errors[0].Details["attempt"] = 2
+
+	if got := original.Errors[0].Details["attempt"]; got != 1 {
+		t.Errorf("node error details = %v, want 1 (clone shared the Details map)", got)
+	}
+}
+
 func TestEnvelope_Clone_Nil(t *testing.T) {
 	var env *Envelope
 	clone := env.Clone()

--- a/runtime/parallel_clone_test.go
+++ b/runtime/parallel_clone_test.go
@@ -1,0 +1,50 @@
+package runtime_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/petal-labs/petalflow/core"
+	"github.com/petal-labs/petalflow/graph"
+	"github.com/petal-labs/petalflow/runtime"
+)
+
+// writeNestedVar returns a node func that repeatedly writes to the nested
+// "shared" map, widening the window in which a shallow clone (shared backing
+// map) would produce a data race under the race detector.
+func writeNestedVar(key string) core.NodeFunc {
+	return func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		if m, ok := env.Vars["shared"].(map[string]any); ok {
+			for i := 0; i < 100; i++ {
+				m[key] = i
+			}
+		}
+		return env, nil
+	}
+}
+
+// TestRuntime_Run_ParallelBranchesIsolateNestedVars fans out to two concurrent
+// branches that both mutate a nested map seeded by the entry node. With a deep
+// Clone each branch owns a separate copy, so there is no data race; with a
+// shallow clone the branches would share the backing map and race. Run under
+// `go test -race` (as CI does) this guards against a regression to shallow clone.
+func TestRuntime_Run_ParallelBranchesIsolateNestedVars(t *testing.T) {
+	g := graph.NewGraph("fanout")
+	g.AddNode(core.NewFuncNode("start", func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		env.SetVar("shared", map[string]any{})
+		return env, nil
+	}))
+	g.AddNode(core.NewFuncNode("a", writeNestedVar("a")))
+	g.AddNode(core.NewFuncNode("b", writeNestedVar("b")))
+	g.AddEdge("start", "a")
+	g.AddEdge("start", "b")
+	g.SetEntry("start")
+
+	rt := runtime.NewRuntime()
+	opts := runtime.DefaultRunOptions()
+	opts.Concurrency = 2
+
+	if _, err := rt.Run(context.Background(), g, core.NewEnvelope(), opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
P1-5. Completes the abandoned-node isolation started by `NodeTimeout` (#141) and fixes a separate parallel-branch data race.

## Problem

`Envelope.Clone()` allocated fresh top-level containers but copied the *values* by reference: `Vars` entries, and the `Meta`/`Bytes`/`Details` fields of `Artifact`/`Message`/`NodeError`, were shared between the original and the clone. The runtime clones envelopes for every parallel branch (`scheduleParallelSuccessors`) and, since #141, for every node under `NodeTimeout`. So two concurrent branches that mutated a nested `map[string]any` in `Vars` — or an artifact's `Meta` — wrote to the **same backing map**: a data race and cross-branch corruption. The doc comment even claimed a deep copy while the code did a shallow one.

## Change

- Deep-copy JSON-like values (`map[string]any`, `[]any`, `[]byte`) recursively throughout `Vars`, and the reference fields of `Artifact` (`Meta`, `Bytes`), `Message` (`Meta`), and `NodeError` (`Details`). Each clone now owns fully independent nested state.
- `Input` and non-JSON-like values (arbitrary structs, pointers, channels) remain copied by reference — they can't be deep-copied generically — and are documented as read-only across branches. Corrected the misleading doc comment.

This also completes #141's guarantee: a node abandoned on timeout now mutates its own nested copies, so it can't corrupt the envelope the caller proceeds with (previously only top-level `Vars` were isolated).

## Testing

- TDD; six deterministic unit tests (nested var map, nested var slice, artifact `Meta`, artifact `Bytes`, message `Meta`, node-error `Details`) written and watched fail against the shallow clone, then pass.
- Added an end-to-end regression test: two parallel branches each mutate a nested map seeded by the entry node under `Concurrency=2`; run under `-race` (as CI does) a shallow-clone regression would trip the race detector.
- Existing top-level `Clone` tests unchanged and passing. `go build/vet/test ./...` green (23 packages, 0 failures); `go test -race ./core/... ./runtime/...` clean.