### PR TITLE
fix: keep SSE streams alive and harden daemon HTTP timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   independent state. This completes the abandoned-node isolation added with
   `NodeTimeout`. `Input` and non-JSON-like values remain copied by reference and
   must be treated as read-only across branches.
+- **Daemon HTTP server no longer severs SSE streams or leaks streaming handlers.**
+  The server's `WriteTimeout` applied to the whole response, so it terminated
+  long-lived Server-Sent Events streams mid-run; the SSE handlers now clear the
+  per-connection write deadline (via `http.ResponseController`) so streams are
+  not cut off. The non-subscription streaming path blocked on the run's done
+  channel with no context handling, leaking the handler when a client
+  disconnected or the run timed out; it now selects on the request context and
+  emits heartbeats like the subscription path.
+
+### Added
 
 - **Per-node timeout (`RunOptions.NodeTimeout`, CLI `--node-timeout`).** When
   set, each node runs with a deadline and the runtime returns as soon as the
@@ -53,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   never returned. Nodes run on a cloned envelope so a node abandoned on timeout
   cannot corrupt the envelope the caller proceeds with. Defaults to 0 (disabled),
   preserving the original inline execution when unset.
+- **HTTP server hardening timeouts.** The daemon now sets `ReadHeaderTimeout`
+  (default 10s, Slowloris protection) and `IdleTimeout` (default 120s) via new
+  `--read-header-timeout` and `--idle-timeout` flags.
 
 ### Changed
 

--- a/cli/serve.go
+++ b/cli/serve.go
@@ -44,11 +44,38 @@ func NewServeCmd() *cobra.Command {
 	cmd.Flags().String("tls-cert", "", "TLS certificate file")
 	cmd.Flags().String("tls-key", "", "TLS key file")
 	cmd.Flags().Duration("read-timeout", 30*time.Second, "HTTP read timeout")
-	cmd.Flags().Duration("write-timeout", 60*time.Second, "HTTP write timeout")
+	cmd.Flags().Duration("write-timeout", 60*time.Second, "HTTP write timeout (does not apply to SSE streams)")
+	cmd.Flags().Duration("read-header-timeout", 10*time.Second, "HTTP read header timeout (Slowloris protection)")
+	cmd.Flags().Duration("idle-timeout", 120*time.Second, "HTTP idle (keep-alive) timeout")
 	cmd.Flags().Int64("max-body", 1<<20, "Max request body size in bytes")
 	cmd.Flags().Duration("workflow-schedule-poll", 5*time.Second, "Workflow schedule poll interval")
 
 	return cmd
+}
+
+// httpServerTimeouts groups the daemon's HTTP server timeout settings.
+type httpServerTimeouts struct {
+	Read       time.Duration
+	Write      time.Duration
+	ReadHeader time.Duration
+	Idle       time.Duration
+}
+
+// buildHTTPServer constructs the daemon HTTP server with hardening timeouts.
+//
+// ReadHeaderTimeout and IdleTimeout guard against slow-header (Slowloris) and
+// leaked keep-alive connections. WriteTimeout bounds normal responses but is
+// cleared per-connection by the SSE handlers (via http.ResponseController), so
+// long-lived event streams are not severed mid-run.
+func buildHTTPServer(addr string, handler http.Handler, t httpServerTimeouts) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadTimeout:       t.Read,
+		WriteTimeout:      t.Write,
+		ReadHeaderTimeout: t.ReadHeader,
+		IdleTimeout:       t.Idle,
+	}
 }
 
 func runServe(cmd *cobra.Command, _ []string) error {
@@ -57,6 +84,8 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	corsOrigin, _ := cmd.Flags().GetString("cors-origin")
 	readTimeout, _ := cmd.Flags().GetDuration("read-timeout")
 	writeTimeout, _ := cmd.Flags().GetDuration("write-timeout")
+	readHeaderTimeout, _ := cmd.Flags().GetDuration("read-header-timeout")
+	idleTimeout, _ := cmd.Flags().GetDuration("idle-timeout")
 	maxBody, _ := cmd.Flags().GetInt64("max-body")
 	workflowSchedulePoll, _ := cmd.Flags().GetDuration("workflow-schedule-poll")
 	tlsCert, _ := cmd.Flags().GetString("tls-cert")
@@ -195,12 +224,12 @@ func runServe(cmd *cobra.Command, _ []string) error {
 	handler = maxBodyMiddleware(handler, maxBody)
 
 	addr := net.JoinHostPort(host, fmt.Sprintf("%d", port))
-	httpServer := &http.Server{
-		Addr:         addr,
-		Handler:      handler,
-		ReadTimeout:  readTimeout,
-		WriteTimeout: writeTimeout,
-	}
+	httpServer := buildHTTPServer(addr, handler, httpServerTimeouts{
+		Read:       readTimeout,
+		Write:      writeTimeout,
+		ReadHeader: readHeaderTimeout,
+		Idle:       idleTimeout,
+	})
 
 	// Signal handling
 	ctx, stop := signal.NotifyContext(cmd.Context(), os.Interrupt, syscall.SIGTERM)

--- a/cli/serve_internal_test.go
+++ b/cli/serve_internal_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestBuildHTTPServer_SetsTimeouts(t *testing.T) {
+	cfg := httpServerTimeouts{
+		Read:       1 * time.Second,
+		Write:      2 * time.Second,
+		Idle:       3 * time.Second,
+		ReadHeader: 4 * time.Second,
+	}
+
+	srv := buildHTTPServer("127.0.0.1:0", http.NotFoundHandler(), cfg)
+
+	if srv.ReadTimeout != cfg.Read {
+		t.Errorf("ReadTimeout = %v, want %v", srv.ReadTimeout, cfg.Read)
+	}
+	if srv.WriteTimeout != cfg.Write {
+		t.Errorf("WriteTimeout = %v, want %v", srv.WriteTimeout, cfg.Write)
+	}
+	if srv.IdleTimeout != cfg.Idle {
+		t.Errorf("IdleTimeout = %v, want %v", srv.IdleTimeout, cfg.Idle)
+	}
+	if srv.ReadHeaderTimeout != cfg.ReadHeader {
+		t.Errorf("ReadHeaderTimeout = %v, want %v", srv.ReadHeaderTimeout, cfg.ReadHeader)
+	}
+}
+
+func TestNewServeCmd_TimeoutFlagDefaults(t *testing.T) {
+	cmd := NewServeCmd()
+
+	idle, err := cmd.Flags().GetDuration("idle-timeout")
+	if err != nil {
+		t.Fatalf("idle-timeout flag: %v", err)
+	}
+	if idle != 120*time.Second {
+		t.Errorf("idle-timeout default = %v, want 120s", idle)
+	}
+
+	readHeader, err := cmd.Flags().GetDuration("read-header-timeout")
+	if err != nil {
+		t.Fatalf("read-header-timeout flag: %v", err)
+	}
+	if readHeader != 10*time.Second {
+		t.Errorf("read-header-timeout default = %v, want 10s", readHeader)
+	}
+}

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -434,7 +434,7 @@ func (s *Server) handleRunStreaming(
 	writer.writeEvent("run.started", map[string]string{"run_id": runID, "workflow_id": id})
 
 	if sub == nil {
-		s.streamWithoutSubscription(writer, doneCh, runID)
+		s.streamWithoutSubscription(ctx, writer, doneCh, runID)
 		return
 	}
 	s.streamWithSubscription(ctx, writer, sub, doneCh, runID)
@@ -457,6 +457,10 @@ func newSSEWriter(w http.ResponseWriter) (*sseWriter, bool) {
 }
 
 func (s *sseWriter) startResponse() {
+	// Clear any server WriteTimeout for this connection so a long-lived event
+	// stream is not severed mid-run. Best-effort: ignored if unsupported.
+	_ = http.NewResponseController(s.w).SetWriteDeadline(time.Time{})
+
 	s.w.Header().Set("Content-Type", "text/event-stream")
 	s.w.Header().Set("Cache-Control", "no-cache")
 	s.w.Header().Set("Connection", "keep-alive")
@@ -515,13 +519,26 @@ func (s *Server) startStreamingRuntime(
 	return doneCh
 }
 
-func (s *Server) streamWithoutSubscription(writer *sseWriter, doneCh <-chan error, runID string) {
-	err := <-doneCh
-	if err != nil {
-		writer.writeEvent("run.error", map[string]string{"error": err.Error()})
-		return
+func (s *Server) streamWithoutSubscription(ctx context.Context, writer *sseWriter, doneCh <-chan error, runID string) {
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	for {
+		select {
+		case err := <-doneCh:
+			if err != nil {
+				writer.writeEvent("run.error", map[string]string{"error": err.Error()})
+				return
+			}
+			writer.writeEvent("run.finished", map[string]string{"run_id": runID, "status": "completed"})
+			return
+		case <-heartbeat.C:
+			writer.writeHeartbeat()
+		case <-ctx.Done():
+			writer.writeEvent("run.error", map[string]string{"error": "timeout"})
+			return
+		}
 	}
-	writer.writeEvent("run.finished", map[string]string{"run_id": runID, "status": "completed"})
 }
 
 func (s *Server) streamWithSubscription(
@@ -614,6 +631,9 @@ func (s *Server) handleRunEvents(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, events)
 		return
 	}
+
+	// Clear any server WriteTimeout for this streaming response.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
 
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")

--- a/server/streaming_handlers_test.go
+++ b/server/streaming_handlers_test.go
@@ -1,0 +1,34 @@
+package server
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestStreamWithoutSubscription_ReturnsOnContextCancel(t *testing.T) {
+	rec := httptest.NewRecorder()
+	writer, ok := newSSEWriter(rec)
+	if !ok {
+		t.Fatal("httptest recorder should support flushing")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	doneCh := make(chan error) // never fires; the run never completes
+
+	returned := make(chan struct{})
+	go func() {
+		(&Server{}).streamWithoutSubscription(ctx, writer, doneCh, "run-1")
+		close(returned)
+	}()
+
+	cancel()
+
+	select {
+	case <-returned:
+		// Good: returned promptly after cancellation.
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamWithoutSubscription did not return after context cancellation")
+	}
+}

--- a/sse/handler.go
+++ b/sse/handler.go
@@ -104,6 +104,10 @@ func (h *SSEHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		afterSeq = parsed
 	}
 
+	// Clear any server WriteTimeout for this connection so the long-lived event
+	// stream is not severed mid-run. Best-effort: ignored if unsupported.
+	_ = http.NewResponseController(w).SetWriteDeadline(time.Time{})
+
 	// Set SSE headers.
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")


### PR DESCRIPTION
Finishes the timeout cluster (P1-7).

## Problems

- **`WriteTimeout` severs SSE streams.** The daemon set `WriteTimeout` (default 60s) on the `http.Server`, which applies to the *entire* response write. Server-Sent Events endpoints hold the response open for the whole run, so any stream longer than `WriteTimeout` was forcibly cut mid-run — an intermittent "timeout" for longer workflows.
- **No `ReadHeaderTimeout` / `IdleTimeout`.** Slow-header (Slowloris) and idle keep-alive connections were unbounded.
- **Streaming-handler goroutine leak.** `streamWithoutSubscription` blocked on `<-doneCh` with no context handling. If the client disconnected or the run timed out, the handler never returned.

## Change

- SSE handlers clear the per-connection write deadline with `http.NewResponseController(w).SetWriteDeadline(time.Time{})` (best-effort), so a normal `WriteTimeout` still bounds regular responses but does not sever streams. Applied at all three SSE entry points: `sseWriter.startResponse` (run streaming), `handleRunEvents` (stored-event replay), and `sse.SSEHandler.ServeHTTP` (live stream).
- `streamWithoutSubscription` now takes the request context and `select`s on `doneCh` / a 15s heartbeat / `ctx.Done()`, matching `streamWithSubscription`, so a disconnect or timeout returns the handler promptly.
- Extract `buildHTTPServer` and set `ReadHeaderTimeout` (default 10s) and `IdleTimeout` (default 120s), exposed via `--read-header-timeout` and `--idle-timeout`.

## Scope note

The detached `rt.Run` goroutine started by the streaming handler is bounded by the run-level context timeout and, for a node that ignores context, by `RunOptions.NodeTimeout` (#141) — outside this PR's HTTP-layer scope.

## Testing

- TDD: `buildHTTPServer` sets all four timeouts; `--idle-timeout`/`--read-header-timeout` flag defaults; `streamWithoutSubscription` returns promptly on context cancellation (previously it would block on the done channel forever). Each watched fail first.
- `go build/vet/test ./...` green (23 packages, 0 failures); gofmt/vet clean.