### PR TITLE
fix: enforce structured LLM output instead of silent text fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   channel with no context handling, leaking the handler when a client
   disconnected or the run timed out; it now selects on the request context and
   emits heartbeats like the subscription path.
-
-### Added
+- **Structured LLM output is no longer silently downgraded to text.** When an
+  LLM node has a `JSONSchema`, it previously stored the model's raw text under
+  the output key whenever the response failed to parse as JSON — so downstream
+  nodes expecting a JSON object silently received a string. The streaming path
+  ignored `JSONSchema` entirely and always stored text. Both paths now require a
+  valid JSON object when a schema is configured, parsing the output and
+  returning an error (surfaced through the node error path) instead of storing a
+  wrong-typed value. Note: this validates that the output is a JSON object, not
+  full JSON Schema conformance.
 
 - **Per-node timeout (`RunOptions.NodeTimeout`, CLI `--node-timeout`).** When
   set, each node runs with a deadline and the runtime returns as soon as the

--- a/nodes/llm.go
+++ b/nodes/llm.go
@@ -3,6 +3,7 @@ package nodes
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"text/template"
@@ -163,12 +164,12 @@ func (n *LLMNode) runSync(ctx context.Context, env *core.Envelope, emit runtime.
 		WithNode(n.ID(), n.Kind()).
 		WithPayload("text", resp.Text))
 
-	// Store output in envelope
-	if n.config.JSONSchema != nil && resp.JSON != nil {
-		env.SetVar(n.config.OutputKey, resp.JSON)
-	} else {
-		env.SetVar(n.config.OutputKey, resp.Text)
+	// Store output in envelope, honoring structured output.
+	output, err := n.finalizeOutput(resp.Text, resp.JSON)
+	if err != nil {
+		return nil, err
 	}
+	env.SetVar(n.config.OutputKey, output)
 
 	// Record token usage
 	env.SetVar(n.config.OutputKey+"_usage", core.TokenUsage{
@@ -278,8 +279,12 @@ func (n *LLMNode) runStreaming(ctx context.Context, env *core.Envelope, streamCl
 		WithNode(n.ID(), n.Kind()).
 		WithPayload("text", text))
 
-	// Store output in envelope
-	env.SetVar(n.config.OutputKey, text)
+	// Store output in envelope, honoring structured output.
+	output, err := n.finalizeOutput(text, nil)
+	if err != nil {
+		return nil, err
+	}
+	env.SetVar(n.config.OutputKey, output)
 
 	// Record token usage
 	env.SetVar(n.config.OutputKey+"_usage", core.TokenUsage(usage))
@@ -364,6 +369,37 @@ func (n *LLMNode) checkBudget(usage core.LLMTokenUsage) error {
 	}
 
 	return nil
+}
+
+// finalizeOutput returns the value to store under the node's OutputKey. When a
+// JSONSchema is configured, structured output is required: the value must be a
+// valid JSON object, otherwise the node returns an error rather than silently
+// storing raw text. preParsed is the provider's already-parsed JSON, if any.
+func (n *LLMNode) finalizeOutput(text string, preParsed map[string]any) (any, error) {
+	if n.config.JSONSchema == nil {
+		return text, nil
+	}
+	if preParsed != nil {
+		return preParsed, nil
+	}
+	parsed, err := parseJSONObject(text)
+	if err != nil {
+		return nil, fmt.Errorf("structured output for node %q: model did not return a valid JSON object: %w", n.ID(), err)
+	}
+	return parsed, nil
+}
+
+// parseJSONObject parses s into a JSON object, rejecting empty or non-object output.
+func parseJSONObject(s string) (map[string]any, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return nil, fmt.Errorf("output was empty")
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(trimmed), &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 // Config returns the node's configuration.

--- a/nodes/llm_test.go
+++ b/nodes/llm_test.go
@@ -3,6 +3,7 @@ package nodes
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -179,6 +180,118 @@ func TestLLMNode_Run_WithJSONSchema(t *testing.T) {
 	jsonOutput := output.(map[string]any)
 	if jsonOutput["name"] != "test" {
 		t.Errorf("expected name 'test', got %v", jsonOutput["name"])
+	}
+}
+
+func TestLLMNode_Run_WithJSONSchema_InvalidJSONErrors(t *testing.T) {
+	client := &mockLLMClient{
+		response: core.LLMResponse{
+			Text: "not json at all",
+			// JSON nil: the provider could not parse structured output.
+		},
+	}
+
+	node := NewLLMNode("test", client, LLMNodeConfig{
+		Model:       "gpt-4",
+		JSONSchema:  map[string]any{"type": "object"},
+		OutputKey:   "result",
+		RetryPolicy: core.RetryPolicy{MaxAttempts: 1, Backoff: time.Millisecond},
+	})
+
+	_, err := node.Run(context.Background(), core.NewEnvelope())
+	if err == nil {
+		t.Fatal("expected an error when structured output is requested but the model returned non-JSON, got nil")
+	}
+	if !strings.Contains(err.Error(), "JSON") {
+		t.Errorf("error = %v, want it to mention invalid JSON", err)
+	}
+}
+
+func TestLLMNode_Run_WithJSONSchema_ParsesTextWhenNotPreParsed(t *testing.T) {
+	client := &mockLLMClient{
+		response: core.LLMResponse{
+			Text: `{"name": "parsed"}`,
+			// JSON nil: force the node to parse the text itself.
+		},
+	}
+
+	node := NewLLMNode("test", client, LLMNodeConfig{
+		Model:      "gpt-4",
+		JSONSchema: map[string]any{"type": "object"},
+		OutputKey:  "result",
+	})
+
+	result, err := node.Run(context.Background(), core.NewEnvelope())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out, ok := result.GetVar("result")
+	if !ok {
+		t.Fatal("expected result to be stored")
+	}
+	m, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("expected result to be a JSON object, got %T", out)
+	}
+	if m["name"] != "parsed" {
+		t.Errorf("result[name] = %v, want %q", m["name"], "parsed")
+	}
+}
+
+func TestLLMNode_Run_Streaming_WithJSONSchema_ParsesJSON(t *testing.T) {
+	client := &mockStreamingLLMClient{
+		chunks: []core.StreamChunk{
+			{Delta: `{"name":`, Index: 0},
+			{Delta: ` "streamed"}`, Index: 1},
+			{Done: true},
+		},
+	}
+
+	node := NewLLMNode("test", client, LLMNodeConfig{
+		Model:      "gpt-4",
+		JSONSchema: map[string]any{"type": "object"},
+		OutputKey:  "result",
+	})
+
+	ctx := runtime.ContextWithEmitter(context.Background(), func(e runtime.Event) {})
+	env := core.NewEnvelope()
+	env.Trace.RunID = "r"
+
+	result, err := node.Run(ctx, env)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out, _ := result.GetVar("result")
+	m, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("expected streamed structured output to be a JSON object, got %T", out)
+	}
+	if m["name"] != "streamed" {
+		t.Errorf("result[name] = %v, want %q", m["name"], "streamed")
+	}
+}
+
+func TestLLMNode_Run_Streaming_WithJSONSchema_InvalidJSONErrors(t *testing.T) {
+	client := &mockStreamingLLMClient{
+		chunks: []core.StreamChunk{
+			{Delta: "plain text", Index: 0},
+			{Done: true},
+		},
+	}
+
+	node := NewLLMNode("test", client, LLMNodeConfig{
+		Model:      "gpt-4",
+		JSONSchema: map[string]any{"type": "object"},
+		OutputKey:  "result",
+	})
+
+	ctx := runtime.ContextWithEmitter(context.Background(), func(e runtime.Event) {})
+	env := core.NewEnvelope()
+	env.Trace.RunID = "r"
+
+	_, err := node.Run(ctx, env)
+	if err == nil {
+		t.Fatal("expected an error when streamed structured output is not valid JSON, got nil")
 	}
 }
 


### PR DESCRIPTION
P1-1 + P1-2 — the structured-output half of the "JSON contracts" pain point.

## Problem

When an `LLMNode` had a `JSONSchema`:

- **Sync path (P1-1):** if the response failed to parse as JSON (`resp.JSON == nil`), the node fell through to storing `resp.Text` — a **string where downstream nodes expect a map** — with no error and no event. The Iris adapter also swallowed the underlying parse error.
- **Streaming path (P1-2):** it built the request with `JSONSchema` but always stored the accumulated **text**, never parsing JSON. So the *same node config* produced a `map` on a non-streaming client and a `string` on a streaming client.

## Change

Both paths now route the stored value through `finalizeOutput(text, preParsed)`:

- No schema → store text (unchanged).
- Schema set → require a valid JSON **object**: use the provider's pre-parsed JSON when present, otherwise parse the text; on invalid/empty output return an error that flows through the normal node error path (fail, or record under `ContinueOnError`).

This makes the contract transport-independent and surfaces bad output instead of silently mis-typing it — consistent with the "make violations visible" theme of this hardening effort.

## Scope note

This validates that structured output is a **JSON object**, which fixes the reported silent-degradation bug. Full **JSON Schema conformance** validation (required fields, types, enums) would need a schema-validation dependency and is a separate follow-up.

## Testing

- TDD; four new tests watched fail first: sync invalid-JSON errors; sync parses text when the provider didn't pre-parse; streaming parses JSON into a map; streaming invalid-JSON errors. Existing `TestLLMNode_Run_WithJSONSchema` (pre-parsed) and the plain streaming/text tests remain green.
- `go build/vet/test ./...` green (23 packages, 0 failures); gofmt/vet clean.