### PR TITLE
fix: deregister MemBus subscriptions on close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   returning an error (surfaced through the node error path) instead of storing a
   wrong-typed value. Note: this validates that the output is a JSON object, not
   full JSON Schema conformance.
+- **`MemBus` now deregisters subscriptions on close.** Closing a subscription
+  previously only closed its channel; the subscription stayed registered on the
+  bus forever. In a long-running daemon every SSE client and run subscription
+  accumulated without bound, leaking memory and making each `Publish` iterate an
+  ever-growing list of dead subscriptions. Closing a subscription now removes it
+  from the bus (deleting empty per-run entries), with lock ordering that avoids
+  deadlocking against concurrent `Publish`.
 
 - **Per-node timeout (`RunOptions.NodeTimeout`, CLI `--node-timeout`).** When
   set, each node runs with a deadline and the runtime returns as soon as the

--- a/bus/membus.go
+++ b/bus/membus.go
@@ -63,6 +63,8 @@ func (b *MemBus) Subscribe(runID string) Subscription {
 	defer b.mu.Unlock()
 
 	sub := newMemSub(b.bufSize)
+	sub.bus = b
+	sub.runID = runID
 	b.subs[runID] = append(b.subs[runID], sub)
 	return sub
 }
@@ -74,6 +76,8 @@ func (b *MemBus) SubscribeAll() Subscription {
 	defer b.mu.Unlock()
 
 	sub := newMemSub(b.bufSize)
+	sub.bus = b
+	sub.global = true
 	b.globalSubs = append(b.globalSubs, sub)
 	return sub
 }
@@ -85,19 +89,53 @@ func (b *MemBus) Close() error {
 
 	b.closed = true
 
-	// Close all run-specific subscriptions.
+	// Close every subscription's channel and drop all registrations. We close
+	// channels directly (markClosed) rather than via sub.close(), which would
+	// re-acquire b.mu to deregister and deadlock while we hold it here.
 	for _, subs := range b.subs {
 		for _, sub := range subs {
-			sub.close()
+			sub.markClosed()
 		}
 	}
-
-	// Close all global subscriptions.
 	for _, sub := range b.globalSubs {
-		sub.close()
+		sub.markClosed()
 	}
 
+	b.subs = make(map[string][]*memSub)
+	b.globalSubs = nil
+
 	return nil
+}
+
+// remove deregisters a subscription from the bus. It is called from
+// memSub.close, which must not hold the subscription lock (Publish takes the
+// bus lock and then the subscription lock, so the reverse order here would
+// risk a deadlock).
+func (b *MemBus) remove(sub *memSub) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if sub.global {
+		b.globalSubs = removeSub(b.globalSubs, sub)
+		return
+	}
+
+	remaining := removeSub(b.subs[sub.runID], sub)
+	if len(remaining) == 0 {
+		delete(b.subs, sub.runID)
+	} else {
+		b.subs[sub.runID] = remaining
+	}
+}
+
+// removeSub returns subs with the first occurrence of target removed.
+func removeSub(subs []*memSub, target *memSub) []*memSub {
+	for i, s := range subs {
+		if s == target {
+			return append(subs[:i], subs[i+1:]...)
+		}
+	}
+	return subs
 }
 
 // memSub is an in-memory subscription.
@@ -105,6 +143,12 @@ type memSub struct {
 	ch     chan runtime.Event
 	mu     sync.Mutex
 	closed bool
+
+	// bus, runID, and global identify where this subscription is registered so
+	// it can deregister itself on Close. Set once at subscription time.
+	bus    *MemBus
+	runID  string
+	global bool
 }
 
 func newMemSub(bufSize int) *memSub {
@@ -124,8 +168,19 @@ func (s *memSub) Close() error {
 	return nil
 }
 
-// close performs the actual channel close, guarded against double-close.
+// close closes the subscription's channel and deregisters it from the bus.
+// Deregistration happens after releasing the subscription lock so it does not
+// invert the bus/subscription lock order used by Publish.
 func (s *memSub) close() {
+	s.markClosed()
+	if s.bus != nil {
+		s.bus.remove(s)
+	}
+}
+
+// markClosed closes the channel, guarded against double-close, without
+// deregistering from the bus.
+func (s *memSub) markClosed() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 

--- a/bus/membus_dereg_test.go
+++ b/bus/membus_dereg_test.go
@@ -1,0 +1,119 @@
+package bus
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/petal-labs/petalflow/runtime"
+)
+
+func runSubscriberCount(b *MemBus, runID string) int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.subs[runID])
+}
+
+func globalSubscriberCount(b *MemBus) int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.globalSubs)
+}
+
+func TestMemBus_Close_DeregistersRunSubscriber(t *testing.T) {
+	b := NewMemBus(MemBusConfig{})
+	sub := b.Subscribe("run-1")
+	if got := runSubscriberCount(b, "run-1"); got != 1 {
+		t.Fatalf("expected 1 subscriber before close, got %d", got)
+	}
+
+	if err := sub.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	if got := runSubscriberCount(b, "run-1"); got != 0 {
+		t.Errorf("expected subscriber deregistered after Close, got %d", got)
+	}
+	b.mu.RLock()
+	_, exists := b.subs["run-1"]
+	b.mu.RUnlock()
+	if exists {
+		t.Error("expected the run-1 key to be deleted once empty")
+	}
+}
+
+func TestMemBus_Close_DeregistersGlobalSubscriber(t *testing.T) {
+	b := NewMemBus(MemBusConfig{})
+	sub := b.SubscribeAll()
+	if got := globalSubscriberCount(b); got != 1 {
+		t.Fatalf("expected 1 global subscriber before close, got %d", got)
+	}
+
+	if err := sub.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	if got := globalSubscriberCount(b); got != 0 {
+		t.Errorf("expected global subscriber deregistered after Close, got %d", got)
+	}
+}
+
+func TestMemBus_Close_RemovesOnlyClosedSubscriber(t *testing.T) {
+	b := NewMemBus(MemBusConfig{})
+	s1 := b.Subscribe("run-1")
+	s2 := b.Subscribe("run-1")
+
+	if err := s1.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	if got := runSubscriberCount(b, "run-1"); got != 1 {
+		t.Fatalf("expected 1 remaining subscriber, got %d", got)
+	}
+
+	// s2 must still receive published events.
+	b.Publish(runtime.Event{RunID: "run-1"})
+	select {
+	case _, ok := <-s2.Events():
+		if !ok {
+			t.Error("s2 channel closed unexpectedly")
+		}
+	default:
+		t.Error("s2 should still receive events after s1 closed")
+	}
+}
+
+func TestMemBus_ConcurrentSubscribeCloseAndPublish(t *testing.T) {
+	b := NewMemBus(MemBusConfig{})
+
+	done := make(chan struct{})
+	var pub sync.WaitGroup
+	pub.Add(1)
+	go func() {
+		defer pub.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				b.Publish(runtime.Event{RunID: "r"})
+			}
+		}
+	}()
+
+	var churn sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		churn.Add(1)
+		go func() {
+			defer churn.Done()
+			s := b.Subscribe("r")
+			s.Close()
+		}()
+	}
+	churn.Wait()
+	close(done)
+	pub.Wait()
+
+	if got := runSubscriberCount(b, "r"); got != 0 {
+		t.Errorf("expected 0 remaining subscribers after churn, got %d", got)
+	}
+}


### PR DESCRIPTION
P1-8. An unbounded memory leak in the long-running daemon.

## Problem

`memSub.close()` only closed the subscription's channel and set a flag — it never removed the subscription from `MemBus.subs` / `MemBus.globalSubs`. `Subscribe`/`SubscribeAll` only ever appended. The SSE handler subscribes per HTTP client and closes on disconnect, so over the life of a daemon **every** run subscription and SSE client accumulated forever: memory growth plus an ever-longer list that each `Publish` iterated (dead subscriptions included).

## Change

- Each `memSub` carries a back-reference to its bus and its registration identity (`runID` / `global`), set at subscribe time.
- `close()` now closes the channel and then calls `bus.remove()` to deregister, deleting the per-run map key when its slice becomes empty.
- `bus.Close()` closes channels via a new `markClosed()` (channel-only) and drops all registrations directly, rather than calling `close()` — which would re-acquire the bus lock to deregister and deadlock while `Close` holds it.

### Lock ordering

`Publish` takes the bus lock (read) and then the subscription lock (`send`). To avoid inverting that, `close()` releases the subscription lock (inside `markClosed`) **before** taking the bus lock in `remove()`. Validated by a concurrency test.

## Testing

- TDD; four tests watched fail first: run-subscription deregistered (and empty key deleted) on close; global subscription deregistered; closing one of two subscribers leaves the other registered and still receiving; a stress test with a concurrent publisher and 100 subscribe/close goroutines ends with zero remaining subscribers.
- `go test -race -count=3 ./bus/` clean (exercises the lock ordering); full `go build/vet/test ./...` green (23 packages, 0 failures).