### PR TITLE
refactor!: unify error handling on the runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Completed the `EnvelopeJSON` wire contract.** Added `input`, per-message and
   per-artifact `meta`, and trace `parent_id`/`span_id`, which were previously
   discarded during serialization.
+- **BREAKING: unified error handling on the runtime.** Nodes now always return
+  their error; the runtime alone decides whether to fail the run or record the
+  error and continue, via `RunOptions.ContinueOnError`. Removed the per-node
+  self-handling policies that made this inconsistent: `ToolNodeConfig.OnError`,
+  `WebhookCallNodeConfig.ErrorPolicy` / the `WebhookCallErrorPolicy` type, the
+  `core.ErrorPolicy` type and its constants, and their `petalflow.*` re-exports.
+  A failing tool or webhook node no longer returns a success envelope with
+  `<output>_error` / `ok:false` result vars — it returns an error like every
+  other node. The `error_policy` field in webhook `webhook_call` graph JSON is
+  now ignored. Migration: to continue past a failed node, set
+  `RunOptions.ContinueOnError` (or the equivalent workflow option) instead of a
+  per-node policy; the error is recorded on the envelope's `errors` array.
 
 ## [0.3.0] - 2026-07-31
 

--- a/core/types.go
+++ b/core/types.go
@@ -138,17 +138,10 @@ func (u TokenUsage) Add(other TokenUsage) TokenUsage {
 	}
 }
 
-// ErrorPolicy defines how a node handles errors.
-type ErrorPolicy string
-
-const (
-	// ErrorPolicyFail causes the node to fail and abort the run (default).
-	ErrorPolicyFail ErrorPolicy = "fail"
-	// ErrorPolicyContinue records the error and continues execution.
-	ErrorPolicyContinue ErrorPolicy = "continue"
-	// ErrorPolicyRecord records the error in the envelope and continues.
-	ErrorPolicyRecord ErrorPolicy = "record"
-)
+// Error handling is uniform across the framework: nodes always return their
+// error, and the runtime decides whether to fail the run or record the error
+// and continue, via RunOptions.ContinueOnError. Nodes do not carry their own
+// error policy.
 
 // =============================================================================
 // LLM Client Interface

--- a/core/types_test.go
+++ b/core/types_test.go
@@ -140,18 +140,6 @@ func TestParseNodeKind(t *testing.T) {
 	}
 }
 
-func TestErrorPolicy_Values(t *testing.T) {
-	if ErrorPolicyFail != "fail" {
-		t.Errorf("ErrorPolicyFail = %v, want 'fail'", ErrorPolicyFail)
-	}
-	if ErrorPolicyContinue != "continue" {
-		t.Errorf("ErrorPolicyContinue = %v, want 'continue'", ErrorPolicyContinue)
-	}
-	if ErrorPolicyRecord != "record" {
-		t.Errorf("ErrorPolicyRecord = %v, want 'record'", ErrorPolicyRecord)
-	}
-}
-
 func TestStreamChunk_ZeroValue(t *testing.T) {
 	var chunk StreamChunk
 	if chunk.Done {

--- a/examples/08_webhooks/README.md
+++ b/examples/08_webhooks/README.md
@@ -157,4 +157,4 @@ In the receiver terminal, you should see the incoming payload printed.
 ## Notes
 
 1. `webhook_trigger` auth in this demo uses `header_token`.
-2. `webhook_call` supports `error_policy`; this example uses `"fail"` so non-2xx responses fail the run.
+2. `webhook_call` returns an error on non-2xx responses; the run then fails, or records the error and continues if the run was started with continue-on-error.

--- a/examples/08_webhooks/webhook_call.graph.json
+++ b/examples/08_webhooks/webhook_call.graph.json
@@ -24,8 +24,7 @@
           "x-petalflow-source": "petalflow-example"
         },
         "template": "{\"event_type\":\"{{.vars.event_type}}\",\"event_id\":\"{{.vars.event_id}}\",\"tenant\":\"{{.vars.tenant}}\",\"event_key\":\"{{.vars.event_key}}\",\"payload\":{{ json .vars }}}",
-        "result_var": "webhook_result",
-        "error_policy": "fail"
+        "result_var": "webhook_result"
       }
     },
     {

--- a/hydrate/llmfactory_test.go
+++ b/hydrate/llmfactory_test.go
@@ -994,7 +994,6 @@ func TestNewLiveNodeFactory_WebhookCallNode(t *testing.T) {
 			"method":            "POST",
 			"headers":           map[string]any{"X-Test": "1"},
 			"template":          "{{ json .vars }}",
-			"error_policy":      "record",
 			"result_var":        "webhook_result",
 			"input_vars":        []any{"summary", "score"},
 			"include_artifacts": true,
@@ -1013,9 +1012,6 @@ func TestNewLiveNodeFactory_WebhookCallNode(t *testing.T) {
 		t.Fatalf("expected *nodes.WebhookCallNode, got %T", node)
 	}
 	cfg := webhookNode.Config()
-	if cfg.ErrorPolicy != nodes.WebhookCallErrorPolicyRecord {
-		t.Fatalf("ErrorPolicy = %q, want %q", cfg.ErrorPolicy, nodes.WebhookCallErrorPolicyRecord)
-	}
 	if cfg.URL != "https://example.com/webhook" {
 		t.Fatalf("URL = %q, want https://example.com/webhook", cfg.URL)
 	}

--- a/nodes/tool.go
+++ b/nodes/tool.go
@@ -29,9 +29,6 @@ type ToolNodeConfig struct {
 
 	// RetryPolicy configures retry behavior for transient failures.
 	RetryPolicy core.RetryPolicy
-
-	// OnError defines how errors are handled.
-	OnError core.ErrorPolicy
 }
 
 // ToolNode executes a tool as a workflow step.
@@ -53,9 +50,6 @@ func NewToolNode(id string, tool core.PetalTool, config ToolNodeConfig) *ToolNod
 	}
 	if config.Timeout == 0 {
 		config.Timeout = 30 * time.Second
-	}
-	if config.OnError == "" {
-		config.OnError = core.ErrorPolicyFail
 	}
 	if config.ToolName == "" && tool != nil {
 		config.ToolName = tool.Name()
@@ -80,9 +74,6 @@ func NewToolNodeWithRegistry(id string, registry *core.ToolRegistry, config Tool
 	if config.Timeout == 0 {
 		config.Timeout = 30 * time.Second
 	}
-	if config.OnError == "" {
-		config.OnError = core.ErrorPolicyFail
-	}
 
 	return &ToolNode{
 		BaseNode: core.NewBaseNode(id, core.NodeKindTool),
@@ -103,7 +94,7 @@ func (n *ToolNode) Run(ctx context.Context, env *core.Envelope) (*core.Envelope,
 	// Get the tool
 	tool, err := n.getTool()
 	if err != nil {
-		return n.handleError(env, err)
+		return nil, err
 	}
 
 	// Get event emitter from context
@@ -112,7 +103,7 @@ func (n *ToolNode) Run(ctx context.Context, env *core.Envelope) (*core.Envelope,
 	// Build arguments from envelope
 	args, err := n.buildArgs(env)
 	if err != nil {
-		return n.handleError(env, fmt.Errorf("failed to build args: %w", err))
+		return nil, fmt.Errorf("failed to build args: %w", err)
 	}
 
 	// Emit tool.call event
@@ -133,14 +124,14 @@ func (n *ToolNode) Run(ctx context.Context, env *core.Envelope) (*core.Envelope,
 
 		// Check if context is done
 		if ctx.Err() != nil {
-			return n.handleError(env, ctx.Err())
+			return nil, ctx.Err()
 		}
 
 		// Wait before retry (except on last attempt)
 		if attempt < n.config.RetryPolicy.MaxAttempts {
 			select {
 			case <-ctx.Done():
-				return n.handleError(env, ctx.Err())
+				return nil, ctx.Err()
 			case <-time.After(n.config.RetryPolicy.Backoff * time.Duration(attempt)):
 			}
 		}
@@ -153,8 +144,8 @@ func (n *ToolNode) Run(ctx context.Context, env *core.Envelope) (*core.Envelope,
 		WithPayload("is_error", lastErr != nil))
 
 	if lastErr != nil {
-		return n.handleError(env, fmt.Errorf("tool %q failed after %d attempts: %w",
-			n.config.ToolName, n.config.RetryPolicy.MaxAttempts, lastErr))
+		return nil, fmt.Errorf("tool %q failed after %d attempts: %w",
+			n.config.ToolName, n.config.RetryPolicy.MaxAttempts, lastErr)
 	}
 
 	// Store output in envelope
@@ -205,31 +196,6 @@ func (n *ToolNode) buildArgs(env *core.Envelope) (map[string]any, error) {
 	}
 
 	return args, nil
-}
-
-// handleError processes errors according to the OnError policy.
-func (n *ToolNode) handleError(env *core.Envelope, err error) (*core.Envelope, error) {
-	switch n.config.OnError {
-	case core.ErrorPolicyContinue, core.ErrorPolicyRecord:
-		// Record error and continue
-		env.AppendError(core.NodeError{
-			NodeID:  n.ID(),
-			Kind:    core.NodeKindTool,
-			Message: err.Error(),
-			At:      time.Now(),
-			Cause:   err,
-			Details: map[string]any{
-				"tool": n.config.ToolName,
-			},
-		})
-		// Set output to nil to indicate failure
-		env.SetVar(n.config.OutputKey, nil)
-		env.SetVar(n.config.OutputKey+"_error", err.Error())
-		return env, nil
-
-	default: // ErrorPolicyFail
-		return nil, err
-	}
 }
 
 // Config returns the node's configuration.

--- a/nodes/tool_test.go
+++ b/nodes/tool_test.go
@@ -72,16 +72,6 @@ func TestNewToolNode_DefaultTimeout(t *testing.T) {
 	}
 }
 
-func TestNewToolNode_DefaultOnError(t *testing.T) {
-	tool := &mockPetalTool{name: "test-tool"}
-	node := NewToolNode("test", tool, ToolNodeConfig{})
-
-	config := node.Config()
-	if config.OnError != core.ErrorPolicyFail {
-		t.Errorf("expected default OnError 'fail', got %q", config.OnError)
-	}
-}
-
 func TestToolNode_Run_BasicExecution(t *testing.T) {
 	tool := &mockPetalTool{
 		name:   "test-tool",
@@ -174,66 +164,25 @@ func TestToolNode_Run_WithStaticArgs(t *testing.T) {
 	}
 }
 
-func TestToolNode_Run_Error_FailPolicy(t *testing.T) {
+func TestToolNode_Run_ToolFailureReturnsError(t *testing.T) {
 	tool := &mockPetalTool{
 		name: "failing-tool",
 		err:  errors.New("tool failed"),
 	}
 
 	node := NewToolNode("test", tool, ToolNodeConfig{
-		OnError:     core.ErrorPolicyFail,
-		RetryPolicy: core.RetryPolicy{MaxAttempts: 1, Backoff: time.Millisecond},
-	})
-
-	env := core.NewEnvelope()
-	_, err := node.Run(context.Background(), env)
-
-	if err == nil {
-		t.Fatal("expected error, got nil")
-	}
-}
-
-func TestToolNode_Run_Error_ContinuePolicy(t *testing.T) {
-	tool := &mockPetalTool{
-		name: "failing-tool",
-		err:  errors.New("tool failed"),
-	}
-
-	node := NewToolNode("test", tool, ToolNodeConfig{
-		OnError:     core.ErrorPolicyContinue,
 		OutputKey:   "result",
 		RetryPolicy: core.RetryPolicy{MaxAttempts: 1, Backoff: time.Millisecond},
 	})
 
-	env := core.NewEnvelope()
-	result, err := node.Run(context.Background(), env)
+	result, err := node.Run(context.Background(), core.NewEnvelope())
 
-	// Should not return error with continue policy
-	if err != nil {
-		t.Fatalf("expected no error with continue policy, got: %v", err)
+	// The node always returns its error; the runtime decides fail vs continue.
+	if err == nil {
+		t.Fatal("expected the tool failure to be returned as an error, got nil")
 	}
-
-	// Output should be nil
-	output, ok := result.GetVar("result")
-	if !ok {
-		t.Fatal("expected result key to exist")
-	}
-	if output != nil {
-		t.Errorf("expected nil output, got %v", output)
-	}
-
-	// Error should be recorded
-	errMsg, ok := result.GetVar("result_error")
-	if !ok {
-		t.Fatal("expected error message to be stored")
-	}
-	if errMsg == "" {
-		t.Error("expected non-empty error message")
-	}
-
-	// Should have error in Errors list
-	if len(result.Errors) != 1 {
-		t.Errorf("expected 1 error recorded, got %d", len(result.Errors))
+	if result != nil {
+		t.Errorf("expected a nil envelope on failure, got %v", result)
 	}
 }
 

--- a/nodes/webhook_call.go
+++ b/nodes/webhook_call.go
@@ -19,15 +19,6 @@ type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// WebhookCallErrorPolicy controls node behavior on outbound request failures.
-type WebhookCallErrorPolicy string
-
-const (
-	WebhookCallErrorPolicyFail     WebhookCallErrorPolicy = "fail"
-	WebhookCallErrorPolicyContinue WebhookCallErrorPolicy = "continue"
-	WebhookCallErrorPolicyRecord   WebhookCallErrorPolicy = "record"
-)
-
 // defaultWebhookTimeout bounds an outbound webhook call when no timeout is
 // configured, so a stalled endpoint cannot hang a run indefinitely.
 const defaultWebhookTimeout = 30 * time.Second
@@ -50,7 +41,6 @@ type WebhookCallNodeConfig struct {
 	IncludeTrace     bool
 	Template         string
 	ResultVar        string
-	ErrorPolicy      WebhookCallErrorPolicy
 	HTTPClient       HTTPClient
 }
 
@@ -61,7 +51,6 @@ func ParseWebhookCallConfig(m map[string]any) (WebhookCallNodeConfig, error) {
 		Method:           strings.TrimSpace(webhookConfigString(m, "method")),
 		Template:         webhookConfigString(m, "template"),
 		ResultVar:        strings.TrimSpace(webhookConfigString(m, "result_var")),
-		ErrorPolicy:      WebhookCallErrorPolicy(strings.TrimSpace(webhookConfigString(m, "error_policy"))),
 		Timeout:          webhookConfigDuration(m, "timeout"),
 		MaxResponseBytes: webhookConfigInt64(m, "max_response_bytes"),
 	}
@@ -100,15 +89,6 @@ func normalizeWebhookCallConfig(cfg WebhookCallNodeConfig) (WebhookCallNodeConfi
 	if !httpMethodTokenPattern.MatchString(cfg.Method) {
 		return WebhookCallNodeConfig{}, fmt.Errorf("method %q is invalid", cfg.Method)
 	}
-	if cfg.ErrorPolicy == "" {
-		cfg.ErrorPolicy = WebhookCallErrorPolicyFail
-	}
-	switch cfg.ErrorPolicy {
-	case WebhookCallErrorPolicyFail, WebhookCallErrorPolicyContinue, WebhookCallErrorPolicyRecord:
-		// valid
-	default:
-		return WebhookCallNodeConfig{}, fmt.Errorf("error_policy must be one of: fail, continue, record")
-	}
 	if cfg.HTTPClient == nil {
 		cfg.HTTPClient = http.DefaultClient
 	}
@@ -140,9 +120,6 @@ func NewWebhookCallNode(id string, config WebhookCallNodeConfig) *WebhookCallNod
 		}
 		if normalized.Method == "" {
 			normalized.Method = http.MethodPost
-		}
-		if normalized.ErrorPolicy == "" {
-			normalized.ErrorPolicy = WebhookCallErrorPolicyFail
 		}
 		if normalized.Timeout <= 0 {
 			normalized.Timeout = defaultWebhookTimeout
@@ -194,7 +171,7 @@ func (n *WebhookCallNode) Run(ctx context.Context, env *core.Envelope) (*core.En
 
 	resp, err := n.config.HTTPClient.Do(req)
 	if err != nil {
-		return n.handleFailure(env, 0, nil, nil, err)
+		return nil, n.fail(err)
 	}
 	defer resp.Body.Close()
 
@@ -206,16 +183,14 @@ func (n *WebhookCallNode) Run(ctx context.Context, env *core.Envelope) (*core.En
 	// than silently truncating it.
 	respBody, readErr := io.ReadAll(io.LimitReader(resp.Body, limit+1))
 	if readErr != nil {
-		return n.handleFailure(env, resp.StatusCode, resp.Header, nil, fmt.Errorf("read response body: %w", readErr))
+		return nil, n.fail(fmt.Errorf("read response body: %w", readErr))
 	}
 	if int64(len(respBody)) > limit {
-		return n.handleFailure(env, resp.StatusCode, resp.Header, nil,
-			fmt.Errorf("response body exceeds max %d bytes", limit))
+		return nil, n.fail(fmt.Errorf("response body exceeds max %d bytes", limit))
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		statusErr := fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		return n.handleFailure(env, resp.StatusCode, resp.Header, respBody, statusErr)
+		return nil, n.fail(fmt.Errorf("unexpected status code: %d", resp.StatusCode))
 	}
 
 	result := env.Clone()
@@ -335,43 +310,11 @@ func webhookCallTemplateFuncs() template.FuncMap {
 	}
 }
 
-func (n *WebhookCallNode) handleFailure(
-	env *core.Envelope,
-	statusCode int,
-	headers http.Header,
-	body []byte,
-	runErr error,
-) (*core.Envelope, error) {
-	result := env.Clone()
-	if n.config.ResultVar != "" {
-		result.SetVar(n.config.ResultVar, map[string]any{
-			"ok":          false,
-			"status_code": statusCode,
-			"headers":     responseHeaders(headers),
-			"body":        string(body),
-			"url":         n.config.URL,
-			"method":      n.config.Method,
-			"error":       runErr.Error(),
-		})
-	}
-
-	switch n.config.ErrorPolicy {
-	case WebhookCallErrorPolicyContinue:
-		return result, nil
-	case WebhookCallErrorPolicyRecord:
-		result.AppendError(core.NodeError{
-			NodeID:  n.ID(),
-			Kind:    core.NodeKindWebhookCall,
-			Message: runErr.Error(),
-			At:      time.Now(),
-			Cause:   runErr,
-		})
-		return result, nil
-	case WebhookCallErrorPolicyFail:
-		fallthrough
-	default:
-		return nil, fmt.Errorf("webhook_call node %s: %w", n.ID(), runErr)
-	}
+// fail wraps a request error with the node identity. The webhook node always
+// returns its error; the runtime decides whether to fail the run or record and
+// continue via RunOptions.ContinueOnError.
+func (n *WebhookCallNode) fail(runErr error) error {
+	return fmt.Errorf("webhook_call node %s: %w", n.ID(), runErr)
 }
 
 func responseHeaders(headers http.Header) map[string]any {

--- a/nodes/webhook_call_test.go
+++ b/nodes/webhook_call_test.go
@@ -30,12 +30,11 @@ func TestWebhookCallNode_Success(t *testing.T) {
 	}
 
 	node := NewWebhookCallNode("call", WebhookCallNodeConfig{
-		URL:         "https://example.com/webhook",
-		Method:      http.MethodPost,
-		Headers:     map[string]string{"X-Test": "yes"},
-		ResultVar:   "webhook_result",
-		ErrorPolicy: WebhookCallErrorPolicyFail,
-		HTTPClient:  mockClient,
+		URL:        "https://example.com/webhook",
+		Method:     http.MethodPost,
+		Headers:    map[string]string{"X-Test": "yes"},
+		ResultVar:  "webhook_result",
+		HTTPClient: mockClient,
 	})
 	env := core.NewEnvelope()
 	env.SetVar("order_id", "ord_123")
@@ -68,50 +67,22 @@ func TestWebhookCallNode_Success(t *testing.T) {
 	}
 }
 
-func TestWebhookCallNode_ErrorPolicy(t *testing.T) {
-	tests := []struct {
-		name          string
-		policy        WebhookCallErrorPolicy
-		wantErr       bool
-		wantRecorded  bool
-		wantResultVar bool
-		statusCode    int
-	}{
-		{name: "fail", policy: WebhookCallErrorPolicyFail, wantErr: true, statusCode: 500},
-		{name: "record", policy: WebhookCallErrorPolicyRecord, wantRecorded: true, wantResultVar: true, statusCode: 500},
-		{name: "continue", policy: WebhookCallErrorPolicyContinue, wantResultVar: true, statusCode: 500},
+func TestWebhookCallNode_NonSuccessStatusReturnsError(t *testing.T) {
+	mockClient := NewMockHTTPClient(500)
+	node := NewWebhookCallNode("call", WebhookCallNodeConfig{
+		URL:        "https://example.com/webhook",
+		Method:     http.MethodPost,
+		ResultVar:  "result",
+		HTTPClient: mockClient,
+	})
+
+	// The node always returns its error; the runtime decides fail vs continue.
+	result, err := node.Run(context.Background(), core.NewEnvelope())
+	if err == nil {
+		t.Fatal("expected an error for a non-2xx response, got nil")
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockClient := NewMockHTTPClient(tt.statusCode)
-			node := NewWebhookCallNode("call", WebhookCallNodeConfig{
-				URL:         "https://example.com/webhook",
-				Method:      http.MethodPost,
-				ResultVar:   "result",
-				ErrorPolicy: tt.policy,
-				HTTPClient:  mockClient,
-			})
-
-			out, err := node.Run(context.Background(), core.NewEnvelope())
-			if tt.wantErr {
-				if err == nil {
-					t.Fatal("expected error, got nil")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if tt.wantRecorded && !out.HasErrors() {
-				t.Fatal("expected recorded node error")
-			}
-			if tt.wantResultVar {
-				if _, ok := out.GetVar("result"); !ok {
-					t.Fatal("expected result var to be set")
-				}
-			}
-		})
+	if result != nil {
+		t.Errorf("expected a nil envelope on failure, got %v", result)
 	}
 }
 
@@ -158,10 +129,9 @@ func (c timeoutHTTPClient) Do(req *http.Request) (*http.Response, error) {
 
 func TestWebhookCallNode_Timeout(t *testing.T) {
 	node := NewWebhookCallNode("call", WebhookCallNodeConfig{
-		URL:         "https://example.com/webhook",
-		Timeout:     10 * time.Millisecond,
-		ErrorPolicy: WebhookCallErrorPolicyFail,
-		HTTPClient:  timeoutHTTPClient{delay: 200 * time.Millisecond},
+		URL:        "https://example.com/webhook",
+		Timeout:    10 * time.Millisecond,
+		HTTPClient: timeoutHTTPClient{delay: 200 * time.Millisecond},
 	})
 
 	_, err := node.Run(context.Background(), core.NewEnvelope())
@@ -170,19 +140,6 @@ func TestWebhookCallNode_Timeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
 		t.Fatalf("timeout error = %v, want context deadline exceeded", err)
-	}
-}
-
-func TestWebhookCallNode_InvalidPolicy(t *testing.T) {
-	_, err := ParseWebhookCallConfig(map[string]any{
-		"url":          "https://example.com",
-		"error_policy": "unknown",
-	})
-	if err == nil {
-		t.Fatal("expected invalid error_policy error, got nil")
-	}
-	if !strings.Contains(err.Error(), "error_policy") {
-		t.Fatalf("error = %v, want error_policy context", err)
 	}
 }
 
@@ -215,7 +172,6 @@ func TestWebhookCallNode_RejectsOversizeResponse(t *testing.T) {
 	node := NewWebhookCallNode("call", WebhookCallNodeConfig{
 		URL:              "https://example.com/webhook",
 		MaxResponseBytes: 8,
-		ErrorPolicy:      WebhookCallErrorPolicyFail,
 		HTTPClient: &MockHTTPClient{
 			Response: &http.Response{
 				StatusCode: 200,
@@ -243,9 +199,6 @@ func TestWebhookCallNode_ConfigDefaults(t *testing.T) {
 	}
 	if cfg.Method != http.MethodPost {
 		t.Fatalf("Method = %q, want POST", cfg.Method)
-	}
-	if cfg.ErrorPolicy != WebhookCallErrorPolicyFail {
-		t.Fatalf("ErrorPolicy = %q, want fail", cfg.ErrorPolicy)
 	}
 }
 

--- a/petalflow.go
+++ b/petalflow.go
@@ -56,9 +56,6 @@ type (
 	// TokenUsage tracks token consumption for cost tracking and budgeting.
 	TokenUsage = core.TokenUsage
 
-	// ErrorPolicy defines how a node handles errors.
-	ErrorPolicy = core.ErrorPolicy
-
 	// LLMClient abstracts a single provider/model backend for PetalFlow.
 	LLMClient = core.LLMClient
 
@@ -139,13 +136,6 @@ const (
 	NodeKindWebhookCall    = core.NodeKindWebhookCall
 	NodeKindWebhookTrigger = core.NodeKindWebhookTrigger
 	NodeKindHuman          = core.NodeKindHuman
-)
-
-// ErrorPolicy constants
-const (
-	ErrorPolicyFail     = core.ErrorPolicyFail
-	ErrorPolicyContinue = core.ErrorPolicyContinue
-	ErrorPolicyRecord   = core.ErrorPolicyRecord
 )
 
 // Core package constructors
@@ -532,9 +522,6 @@ type (
 	// WebhookCallNodeConfig configures a WebhookCallNode.
 	WebhookCallNodeConfig = nodes.WebhookCallNodeConfig
 
-	// WebhookCallErrorPolicy defines how webhook_call errors are handled.
-	WebhookCallErrorPolicy = nodes.WebhookCallErrorPolicy
-
 	// WebhookTriggerNode maps inbound webhook requests into workflow vars.
 	WebhookTriggerNode = nodes.WebhookTriggerNode
 
@@ -650,13 +637,6 @@ const (
 	HumanTimeoutFail    = nodes.HumanTimeoutFail
 	HumanTimeoutDefault = nodes.HumanTimeoutDefault
 	HumanTimeoutSkip    = nodes.HumanTimeoutSkip
-)
-
-// WebhookCallErrorPolicy constants
-const (
-	WebhookCallErrorPolicyFail     = nodes.WebhookCallErrorPolicyFail
-	WebhookCallErrorPolicyContinue = nodes.WebhookCallErrorPolicyContinue
-	WebhookCallErrorPolicyRecord   = nodes.WebhookCallErrorPolicyRecord
 )
 
 // Webhook auth mode constants.


### PR DESCRIPTION
P1-6 — the last P1. **Breaking change** (pre-1.0), approved for this stability track.

## Problem

Error handling was inconsistent across nodes:
- `ToolNode.OnError` and `WebhookCallNode.ErrorPolicy` let those nodes **self-handle** failures — returning a *success* envelope with `<output>_error` / `ok:false` result vars — so the runtime's `ContinueOnError` never applied to them.
- `LLMNode` and other nodes had no policy and always returned their error, deferring to the runtime.
- Three overlapping representations: `runtime.RunOptions.ContinueOnError` (bool), `MapNode.ContinueOnError` (bool), `core.ErrorPolicy` (enum), and `WebhookCallErrorPolicy` (an identical duplicate enum) — two of them public and re-exported.

Net: which nodes recorded errors, where, and under which flag was hard to reason about.

## Change

One model: **nodes always return their error; the runtime alone decides fail vs record-and-continue via `RunOptions.ContinueOnError`.**

Removed:
- `ToolNodeConfig.OnError` + `ToolNode.handleError` (and the `<output>=nil` / `<output>_error` convention)
- `WebhookCallNodeConfig.ErrorPolicy`, the `WebhookCallErrorPolicy` type + constants, and `WebhookCallNode.handleFailure`'s policy switch
- `core.ErrorPolicy` type + `ErrorPolicyFail/Continue/Record`
- All corresponding `petalflow.*` re-exports

Tool and webhook nodes now return their error directly; it surfaces on the envelope `errors` array (already serialized to callers via #138). The `error_policy` field in `webhook_call` graph JSON is now ignored. `MapNode.ContinueOnError` is unchanged — it governs per-item behavior *within* a map fan-out, a distinct axis.

Net diff: **−221 lines.**

## Migration

To continue past a failed node, set `RunOptions.ContinueOnError` (or the equivalent workflow option) instead of a per-node policy. The failed node's error is recorded on the envelope's `errors` array.

## Testing

- Updated all affected tests to the new contract: tool/webhook failures return an error (nil envelope), no `*_error` vars; removed the now-obsolete policy-table and invalid-policy tests; dropped the `core.ErrorPolicy` constant test.
- Updated the webhooks example graph JSON + README.
- `go build/vet/test ./...` green (23 packages, 0 failures); `go test -race ./nodes/... ./runtime/...` clean; `irisadapter` module builds.