### PR TITLE
feat: reject unknown fields when loading workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the bus (deleting empty per-run entries), with lock ordering that avoids
   deadlocking against concurrent `Publish`.
 
+### Added
+
+- **Unknown fields in workflow files are no longer silently ignored.** Loading a
+  graph definition, an agent/task workflow, or the provider config file now
+  rejects unknown structural fields (`DisallowUnknownFields`), so a typo like
+  `nodez` or a misspelled node field fails at load time instead of being
+  dropped. Unknown keys inside a node's freeform `config` are reported as
+  non-fatal `GR-020` validation warnings (via a per-type recognized-key set in
+  the registry), so a typo like `timout` surfaces without rejecting workflows
+  when a type's key set is incomplete. This surfaced and fixed a latent bug in
+  the `06_cli_workflow` greeting example (it used `output_key` and no transform
+  type; now `transform: template` + `output_var`).
 - **Per-node timeout (`RunOptions.NodeTimeout`, CLI `--node-timeout`).** When
   set, each node runs with a deadline and the runtime returns as soon as the
   deadline or the parent context fires, even if the node itself ignores

--- a/agent/schema.go
+++ b/agent/schema.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -69,9 +70,13 @@ func LoadFromFile(path string) (*AgentWorkflow, error) {
 }
 
 // LoadFromBytes parses Agent/Task JSON from bytes into an AgentWorkflow.
+// Unknown structural fields are rejected so typos surface at load time rather
+// than being silently ignored.
 func LoadFromBytes(data []byte) (*AgentWorkflow, error) {
 	var wf AgentWorkflow
-	if err := json.Unmarshal(data, &wf); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&wf); err != nil {
 		return nil, fmt.Errorf("parsing agent workflow JSON: %w", err)
 	}
 	return &wf, nil

--- a/agent/strict_test.go
+++ b/agent/strict_test.go
@@ -1,0 +1,26 @@
+package agent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadFromBytes_RejectsUnknownField(t *testing.T) {
+	data := []byte(`{"version":"1.0","kind":"agent_workflow","id":"w","name":"n","agents":{},"tasks":{},"execution":{"strategy":"sequential"},"bogus":true}`)
+
+	_, err := LoadFromBytes(data)
+	if err == nil {
+		t.Fatal("expected an error for an unknown field, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("error = %v, want it to name the unknown field", err)
+	}
+}
+
+func TestLoadFromBytes_AcceptsKnownFields(t *testing.T) {
+	data := []byte(`{"version":"1.0","kind":"agent_workflow","id":"w","name":"n","agents":{},"tasks":{},"execution":{"strategy":"sequential"}}`)
+
+	if _, err := LoadFromBytes(data); err != nil {
+		t.Fatalf("unexpected error for a valid workflow: %v", err)
+	}
+}

--- a/examples/06_cli_workflow/greeting.graph.json
+++ b/examples/06_cli_workflow/greeting.graph.json
@@ -8,8 +8,9 @@
       "id": "greet",
       "type": "transform",
       "config": {
+        "transform": "template",
         "template": "Hello, {{.name}}! Welcome to PetalFlow.",
-        "output_key": "greeting"
+        "output_var": "greeting"
       }
     }
   ],

--- a/graph/config_keys_test.go
+++ b/graph/config_keys_test.go
@@ -1,0 +1,64 @@
+package graph
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/petal-labs/petalflow/registry"
+)
+
+func TestValidateWithRegistry_WarnsOnUnknownConfigKey(t *testing.T) {
+	gd := &GraphDefinition{
+		ID:      "g",
+		Version: "1.0",
+		Nodes: []NodeDef{
+			{ID: "a", Type: "webhook_call", Config: map[string]any{"url": "https://x", "timout": 5}},
+		},
+		Entry: "a",
+	}
+
+	diags := gd.ValidateWithRegistry(registry.Global())
+
+	foundWarn := false
+	for _, d := range diags {
+		if d.Code == "GR-020" && d.Severity == SeverityWarning && strings.Contains(d.Message, "timout") {
+			foundWarn = true
+		}
+	}
+	if !foundWarn {
+		t.Errorf("expected a GR-020 warning naming unknown config key 'timout', got diags: %+v", diags)
+	}
+
+	// Unknown config keys must be a warning, not a hard error.
+	if HasErrors(filterByCode(diags, "GR-020")) {
+		t.Error("unknown config key should be a warning, not an error")
+	}
+}
+
+func TestValidateWithRegistry_NoWarnOnKnownConfigKeys(t *testing.T) {
+	gd := &GraphDefinition{
+		ID:      "g",
+		Version: "1.0",
+		Nodes: []NodeDef{
+			{ID: "a", Type: "webhook_call", Config: map[string]any{"url": "https://x", "method": "POST", "timeout": "5s"}},
+		},
+		Entry: "a",
+	}
+
+	diags := gd.ValidateWithRegistry(registry.Global())
+	for _, d := range diags {
+		if d.Code == "GR-020" {
+			t.Errorf("unexpected config-key warning for a valid config: %s", d.Message)
+		}
+	}
+}
+
+func filterByCode(diags []Diagnostic, code string) []Diagnostic {
+	var out []Diagnostic
+	for _, d := range diags {
+		if d.Code == code {
+			out = append(out, d)
+		}
+	}
+	return out
+}

--- a/graph/definition.go
+++ b/graph/definition.go
@@ -2,6 +2,7 @@ package graph
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/petal-labs/petalflow/core"
 	"github.com/petal-labs/petalflow/registry"
@@ -219,6 +220,39 @@ func (gd *GraphDefinition) validateSchemaHeader() []Diagnostic {
 	return diags
 }
 
+// unknownConfigKeyDiagnostics returns GR-020 warnings for config keys on a node
+// that are not in its type's recognized ConfigKeys set. When a type declares no
+// ConfigKeys (nil/empty), no warnings are emitted so unannotated types are safe.
+func unknownConfigKeyDiagnostics(i int, node NodeDef, def registry.NodeTypeDef) []Diagnostic {
+	if len(def.ConfigKeys) == 0 || len(node.Config) == 0 {
+		return nil
+	}
+
+	known := make(map[string]bool, len(def.ConfigKeys))
+	for _, k := range def.ConfigKeys {
+		known[k] = true
+	}
+
+	unknown := make([]string, 0)
+	for k := range node.Config {
+		if !known[k] {
+			unknown = append(unknown, k)
+		}
+	}
+	sort.Strings(unknown)
+
+	diags := make([]Diagnostic, 0, len(unknown))
+	for _, k := range unknown {
+		diags = append(diags, Diagnostic{
+			Code:     "GR-020",
+			Severity: SeverityWarning,
+			Message:  fmt.Sprintf("Node %q has unrecognized config key %q for type %q", node.ID, k, node.Type),
+			Path:     fmt.Sprintf("nodes[%d].config.%s", i, k),
+		})
+	}
+	return diags
+}
+
 // ValidateWithRegistry runs structural validation plus registry-dependent checks:
 //   - GR-003: node type must exist in the registry
 //   - GR-006: source handle should map to a declared output port when static
@@ -260,6 +294,11 @@ func (gd *GraphDefinition) ValidateWithRegistry(reg *registry.Registry) []Diagno
 				Path:     fmt.Sprintf("nodes[%d].type", i),
 			})
 		}
+
+		// GR-020: warn (non-fatal) on unrecognized config keys, so typos in a
+		// node's config surface without rejecting workflows when a type's known
+		// key set is incomplete.
+		diags = append(diags, unknownConfigKeyDiagnostics(i, node, def)...)
 	}
 
 	// Validate source handles where port sets are static.

--- a/hydrate/hydrate.go
+++ b/hydrate/hydrate.go
@@ -1,6 +1,7 @@
 package hydrate
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -99,9 +100,21 @@ func loadConfigFile() (*Config, error) {
 		return nil, fmt.Errorf("reading config file %s: %w", path, err)
 	}
 
-	var cfg Config
-	if err := json.Unmarshal(data, &cfg); err != nil {
+	cfg, err := parseConfigBytes(data)
+	if err != nil {
 		return nil, fmt.Errorf("parsing config file %s: %w", path, err)
+	}
+	return cfg, nil
+}
+
+// parseConfigBytes decodes the provider config, rejecting unknown fields so
+// typos in the config file surface instead of being silently ignored.
+func parseConfigBytes(data []byte) (*Config, error) {
+	var cfg Config
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, err
 	}
 	return &cfg, nil
 }

--- a/hydrate/strict_test.go
+++ b/hydrate/strict_test.go
@@ -1,0 +1,26 @@
+package hydrate
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseConfigBytes_RejectsUnknownField(t *testing.T) {
+	data := []byte(`{"providers":{},"bogus":true}`)
+
+	_, err := parseConfigBytes(data)
+	if err == nil {
+		t.Fatal("expected an error for an unknown config field, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Errorf("error = %v, want it to name the unknown field", err)
+	}
+}
+
+func TestParseConfigBytes_AcceptsKnownFields(t *testing.T) {
+	data := []byte(`{"providers":{"openai":{"api_key":"sk-x"}},"defaults":{"provider":"openai"}}`)
+
+	if _, err := parseConfigBytes(data); err != nil {
+		t.Fatalf("unexpected error for a valid config: %v", err)
+	}
+}

--- a/loader/load.go
+++ b/loader/load.go
@@ -1,6 +1,7 @@
 package loader
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -89,7 +90,9 @@ func loadGraphDefinition(data []byte, path string) (*graph.GraphDefinition, erro
 	}
 
 	var gd graph.GraphDefinition
-	if err := json.Unmarshal(jsonData, &gd); err != nil {
+	dec := json.NewDecoder(bytes.NewReader(jsonData))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&gd); err != nil {
 		return nil, fmt.Errorf("parsing graph definition: %w", err)
 	}
 

--- a/loader/strict_test.go
+++ b/loader/strict_test.go
@@ -1,0 +1,35 @@
+package loader
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLoadGraphDefinition_RejectsUnknownTopLevelField(t *testing.T) {
+	data := []byte(`{"id":"g","version":"1.0","nodes":[{"id":"a","type":"noop"}],"edges":[],"entry":"a","bogus_field":true}`)
+
+	_, err := loadGraphDefinition(data, "test.json")
+	if err == nil {
+		t.Fatal("expected an error for an unknown top-level field, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogus_field") {
+		t.Errorf("error = %v, want it to name the unknown field", err)
+	}
+}
+
+func TestLoadGraphDefinition_RejectsUnknownNodeField(t *testing.T) {
+	data := []byte(`{"id":"g","version":"1.0","nodes":[{"id":"a","type":"noop","bogus":1}],"edges":[],"entry":"a"}`)
+
+	_, err := loadGraphDefinition(data, "test.json")
+	if err == nil {
+		t.Fatal("expected an error for an unknown node field, got nil")
+	}
+}
+
+func TestLoadGraphDefinition_AcceptsKnownFields(t *testing.T) {
+	data := []byte(`{"id":"g","version":"1.0","kind":"graph","nodes":[{"id":"a","type":"noop","config":{}}],"edges":[],"entry":"a"}`)
+
+	if _, err := loadGraphDefinition(data, "test.json"); err != nil {
+		t.Fatalf("unexpected error for a valid graph: %v", err)
+	}
+}

--- a/registry/builtins.go
+++ b/registry/builtins.go
@@ -267,4 +267,41 @@ func registerBuiltins(r *Registry) {
 			},
 		},
 	})
+
+	applyBuiltinConfigKeys(r)
+}
+
+// builtinConfigKeys lists the config keys the hydrate factory recognizes for
+// each built-in node type. Keys not listed here trigger a non-fatal GR-020
+// warning at load time. Types absent from this map (e.g. noop, func) accept no
+// config and are not checked. Keep in sync with hydrate/llmfactory.go.
+var builtinConfigKeys = map[string][]string{
+	"llm_prompt":      {"provider", "model", "system_prompt", "prompt_template", "output_key", "temperature", "max_tokens"},
+	"llm_router":      {"provider", "model", "system_prompt", "decision_key", "temperature", "allowed_targets"},
+	"rule_router":     {"default_target", "decision_key", "allow_multiple", "rules"},
+	"filter":          {"target", "input_var", "output_var", "stats_var", "filters"},
+	"transform":       {"transform", "input_var", "output_var", "template", "format", "separator", "merge_strategy", "input_vars", "fields"},
+	"merge":           {"output_key", "strategy", "var_name", "separator", "score_var", "higher_is_better"},
+	"gate":            {"condition_var", "on_fail", "fail_message", "redirect_node_id", "result_var"},
+	"guardian":        {"input_var", "on_fail", "fail_message", "redirect_node_id", "result_var", "stop_on_first_failure", "checks"},
+	"human":           {"mode", "prompt", "output_var", "timeout"},
+	"map":             {"input_var", "output_var", "item_var", "index_var", "concurrency", "continue_on_error", "preserve_order", "mapper_binding", "mapper_node"},
+	"cache":           {"cache_key", "ttl", "output_var", "output_key", "input_vars", "include_artifacts", "include_input", "wrapped_binding", "wrapped_node"},
+	"conditional":     {"default", "output_key", "evaluation_order", "pass_through", "conditions"},
+	"webhook_trigger": {"methods", "auth", "request_var", "body_var", "headers_var", "query_var", "metadata_var", "timeout"},
+	"webhook_call":    {"url", "method", "headers", "timeout", "max_response_bytes", "template", "result_var", "input_vars", "include_artifacts", "include_messages", "include_trace"},
+	"tool":            {"tool_name", "args_template", "static_args", "output_key", "timeout"},
+}
+
+// applyBuiltinConfigKeys attaches the recognized config keys to each registered
+// built-in type, re-registering it (which overwrites in place, preserving order).
+func applyBuiltinConfigKeys(r *Registry) {
+	for typ, keys := range builtinConfigKeys {
+		def, ok := r.Get(typ)
+		if !ok {
+			continue
+		}
+		def.ConfigKeys = keys
+		r.Register(def)
+	}
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -12,9 +12,10 @@ type NodeTypeDef struct {
 	DisplayName  string     `json:"display_name"`
 	Description  string     `json:"description"`
 	Ports        PortSchema `json:"ports"`
-	ConfigSchema any        `json:"config_schema"` // JSON Schema for config validation
-	IsTool       bool       `json:"is_tool"`       // usable as an agent tool
-	ToolMode     string     `json:"tool_mode"`     // "function_call" | "standalone" | ""
+	ConfigSchema any        `json:"config_schema"`         // JSON Schema for config validation
+	ConfigKeys   []string   `json:"config_keys,omitempty"` // recognized config keys; unknown keys warn on load
+	IsTool       bool       `json:"is_tool"`               // usable as an agent tool
+	ToolMode     string     `json:"tool_mode"`             // "function_call" | "standalone" | ""
 }
 
 // PortSchema defines the input and output ports for a node type.


### PR DESCRIPTION
Closes #147. Structural strict decoding (hard error) + node-config key warnings, per the agreed scope.

## Problem
Unknown/misspelled fields in `.graph.json`, `.agent.yaml`, and the provider config file were **silently ignored** — a typo like `nodez` or `"timout"` behaved differently than authored with no signal.

## Change

**Structural fields → hard error.** Decode graph definitions (`loader`), agent/task workflows (`agent.LoadFromBytes`), and the provider config file (`hydrate`) with `DisallowUnknownFields`. A misspelled top-level, node, or edge field now fails at load time.

**Node `config` keys → non-fatal warning.** A node's `config` is a freeform `map[string]any`, so struct decoding can't catch typos inside it. Instead, validate config keys against a per-type recognized-key set:
- Added `NodeTypeDef.ConfigKeys` to the registry, populated for all built-in types (`registry/builtins.go`, kept in sync with `hydrate/llmfactory.go`).
- `ValidateWithRegistry` emits a `GR-020` **warning** (not error) for any config key not in the type's set.
- Types with no declared keys (`noop`, `func`) are not checked. Warnings never reject a workflow, so an incomplete key set can't break a valid graph — matching the agreed "safe by default" choice.

**Bonus:** the warning immediately surfaced a latent bug in the `06_cli_workflow` greeting quickstart example — it set `output_key` with no `transform` type and **failed at run time** (`unknown transform type`). Corrected to `transform: template` + `output_var`; it now validates clean and runs.

Also restored a `### Added` CHANGELOG header that was dropped in an earlier merge.

## Testing
- TDD across all four surfaces. Structural: reject unknown top-level/node field (graph), reject unknown field (agent), reject unknown config field (provider config), plus accepts-valid counterparts. Warnings: unknown config key produces a `GR-020` warning (not error); known keys produce none.
- Verified no example/testdata workflow carries extra structural fields (would break strict decoding) before enabling it.
- `go build/vet/test ./...` green (23 packages, 0 failures); gofmt/vet clean. Manually confirmed the greeting example now validates clean and runs.