### PR TITLE
fix: surface tool-argument errors instead of corrupting silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ever-growing list of dead subscriptions. Closing a subscription now removes it
   from the bus (deleting empty per-run entries), with lock ordering that avoids
   deadlocking against concurrent `Publish`.
+- **Tool-call argument handling no longer corrupts silently.** The Iris adapter
+  swallowed the error when a model returned tool-call arguments that were not
+  valid JSON (running the tool with empty args) and coerced any unrecognized
+  message role to `user`; both now return an error. Tool nodes gained an opt-in
+  `RequiredArgs` (config `required_args`): if a required argument does not
+  resolve from the envelope, the node returns an error instead of invoking the
+  tool with missing arguments.
 
 ### Added
 

--- a/hydrate/llmfactory.go
+++ b/hydrate/llmfactory.go
@@ -558,19 +558,15 @@ func cloneAnyMap(m map[string]any) map[string]any {
 
 // buildToolNode creates a ToolNode from a NodeDef and a resolved tool.
 func buildToolNode(nd graph.NodeDef, tool core.PetalTool) *nodes.ToolNode {
-	cfg := nodes.ToolNodeConfig{
-		ToolName:     nd.Type,
-		ArgsTemplate: configStringMap(nd.Config, "args_template"),
-		StaticArgs:   cloneAnyMap(configMapAnyMap(nd.Config, "static_args")),
-		OutputKey:    configString(nd.Config, "output_key"),
-		Timeout:      configDuration(nd.Config, "timeout"),
-	}
-
-	return nodes.NewToolNode(nd.ID, tool, cfg)
+	return nodes.NewToolNode(nd.ID, tool, toolNodeConfig(nd, nd.Type))
 }
 
 // buildToolNodeWithName creates a ToolNode from a NodeDef using an explicit tool name.
 func buildToolNodeWithName(nd graph.NodeDef, toolName string, tool core.PetalTool) *nodes.ToolNode {
+	return nodes.NewToolNode(nd.ID, tool, toolNodeConfig(nd, toolName))
+}
+
+func toolNodeConfig(nd graph.NodeDef, toolName string) nodes.ToolNodeConfig {
 	cfg := nodes.ToolNodeConfig{
 		ToolName:     toolName,
 		ArgsTemplate: configStringMap(nd.Config, "args_template"),
@@ -578,8 +574,10 @@ func buildToolNodeWithName(nd graph.NodeDef, toolName string, tool core.PetalToo
 		OutputKey:    configString(nd.Config, "output_key"),
 		Timeout:      configDuration(nd.Config, "timeout"),
 	}
-
-	return nodes.NewToolNode(nd.ID, tool, cfg)
+	if req, ok := configStringSlice(nd.Config, "required_args"); ok {
+		cfg.RequiredArgs = req
+	}
+	return cfg
 }
 
 func buildRuleRouter(nd graph.NodeDef) (core.Node, error) {

--- a/irisadapter/provider.go
+++ b/irisadapter/provider.go
@@ -23,7 +23,10 @@ func NewProviderAdapter(provider core.Provider) *ProviderAdapter {
 // Complete sends a completion request to the underlying provider.
 func (a *ProviderAdapter) Complete(ctx context.Context, req petalflow.LLMRequest) (petalflow.LLMResponse, error) {
 	// Convert LLMRequest to core.ChatRequest
-	chatReq := a.toCoreChatRequest(req)
+	chatReq, err := a.toCoreChatRequest(req)
+	if err != nil {
+		return petalflow.LLMResponse{}, err
+	}
 
 	// Call the provider
 	chatResp, err := a.provider.Chat(ctx, chatReq)
@@ -32,11 +35,11 @@ func (a *ProviderAdapter) Complete(ctx context.Context, req petalflow.LLMRequest
 	}
 
 	// Convert core.ChatResponse to LLMResponse
-	return a.fromCoreChatResponse(chatResp, req), nil
+	return a.fromCoreChatResponse(chatResp, req)
 }
 
 // toCoreChatRequest converts a petalflow.LLMRequest to core.ChatRequest.
-func (a *ProviderAdapter) toCoreChatRequest(req petalflow.LLMRequest) *core.ChatRequest {
+func (a *ProviderAdapter) toCoreChatRequest(req petalflow.LLMRequest) (*core.ChatRequest, error) {
 	messages := make([]core.Message, 0, len(req.Messages)+2)
 
 	// Add system message if provided
@@ -49,8 +52,12 @@ func (a *ProviderAdapter) toCoreChatRequest(req petalflow.LLMRequest) *core.Chat
 
 	// Add conversation messages
 	for _, m := range req.Messages {
+		role, err := toRole(m.Role)
+		if err != nil {
+			return nil, err
+		}
 		msg := core.Message{
-			Role:    toRole(m.Role),
+			Role:    role,
 			Content: m.Content,
 		}
 
@@ -105,11 +112,11 @@ func (a *ProviderAdapter) toCoreChatRequest(req petalflow.LLMRequest) *core.Chat
 		chatReq.MaxTokens = req.MaxTokens
 	}
 
-	return chatReq
+	return chatReq, nil
 }
 
 // fromCoreChatResponse converts a core.ChatResponse to petalflow.LLMResponse.
-func (a *ProviderAdapter) fromCoreChatResponse(resp *core.ChatResponse, req petalflow.LLMRequest) petalflow.LLMResponse {
+func (a *ProviderAdapter) fromCoreChatResponse(resp *core.ChatResponse, req petalflow.LLMRequest) (petalflow.LLMResponse, error) {
 	result := petalflow.LLMResponse{
 		Text:     resp.Output,
 		Provider: a.provider.ID(),
@@ -142,7 +149,9 @@ func (a *ProviderAdapter) fromCoreChatResponse(resp *core.ChatResponse, req peta
 		for i, tc := range resp.ToolCalls {
 			args := make(map[string]any)
 			if len(tc.Arguments) > 0 {
-				_ = json.Unmarshal(tc.Arguments, &args) // Best effort parsing
+				if err := json.Unmarshal(tc.Arguments, &args); err != nil {
+					return petalflow.LLMResponse{}, fmt.Errorf("tool call %q (%s) has invalid JSON arguments: %w", tc.ID, tc.Name, err)
+				}
 			}
 			result.ToolCalls[i] = petalflow.LLMToolCall{
 				ID:        tc.ID,
@@ -172,22 +181,23 @@ func (a *ProviderAdapter) fromCoreChatResponse(resp *core.ChatResponse, req peta
 	}
 	result.Messages = append(result.Messages, assistantMsg)
 
-	return result
+	return result, nil
 }
 
-// toRole converts a string role to core.Role.
-func toRole(role string) core.Role {
+// toRole converts a string role to core.Role, returning an error for an
+// unrecognized role rather than silently coercing it to "user".
+func toRole(role string) (core.Role, error) {
 	switch role {
 	case "system":
-		return core.RoleSystem
+		return core.RoleSystem, nil
 	case "user":
-		return core.RoleUser
+		return core.RoleUser, nil
 	case "assistant":
-		return core.RoleAssistant
+		return core.RoleAssistant, nil
 	case "tool":
-		return core.RoleTool
+		return core.RoleTool, nil
 	default:
-		return core.RoleUser
+		return "", fmt.Errorf("unknown message role %q", role)
 	}
 }
 

--- a/irisadapter/provider_test.go
+++ b/irisadapter/provider_test.go
@@ -3,6 +3,7 @@ package irisadapter
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/petal-labs/iris/core"
@@ -289,14 +290,22 @@ func TestToRole(t *testing.T) {
 		{"system", core.RoleSystem},
 		{"user", core.RoleUser},
 		{"assistant", core.RoleAssistant},
-		{"unknown", core.RoleUser}, // default
 	}
 
 	for _, tt := range tests {
-		result := toRole(tt.input)
+		result, err := toRole(tt.input)
+		if err != nil {
+			t.Errorf("toRole(%q) unexpected error: %v", tt.input, err)
+		}
 		if result != tt.expected {
 			t.Errorf("toRole(%q) = %v, expected %v", tt.input, result, tt.expected)
 		}
+	}
+}
+
+func TestToRole_UnknownReturnsError(t *testing.T) {
+	if _, err := toRole("unknown"); err == nil {
+		t.Error("expected an error for an unknown role, got nil")
 	}
 }
 
@@ -318,7 +327,10 @@ func (c *capturingProvider) Chat(ctx context.Context, req *core.ChatRequest) (*c
 }
 
 func TestToRole_Tool(t *testing.T) {
-	result := toRole("tool")
+	result, err := toRole("tool")
+	if err != nil {
+		t.Fatalf("toRole(\"tool\") unexpected error: %v", err)
+	}
 	if result != core.RoleTool {
 		t.Errorf("toRole(\"tool\") = %v, expected %v", result, core.RoleTool)
 	}
@@ -522,5 +534,41 @@ func TestProviderAdapter_Complete_ToolCallsInMessage(t *testing.T) {
 	}
 	if assistantMsg.ToolCalls[0].ID != "call-1" {
 		t.Errorf("expected tool call ID 'call-1', got %q", assistantMsg.ToolCalls[0].ID)
+	}
+}
+
+func TestProviderAdapter_Complete_UnknownRoleErrors(t *testing.T) {
+	adapter := NewProviderAdapter(&mockProvider{id: "mock"})
+
+	_, err := adapter.Complete(context.Background(), petalflow.LLMRequest{
+		Model:    "mock-model",
+		Messages: []petalflow.LLMMessage{{Role: "bogus_role", Content: "hi"}},
+	})
+	if err == nil {
+		t.Fatal("expected an error for an unknown message role, got nil")
+	}
+	if !strings.Contains(err.Error(), "bogus_role") {
+		t.Errorf("error = %v, want it to name the unknown role", err)
+	}
+}
+
+func TestProviderAdapter_Complete_MalformedToolArgsErrors(t *testing.T) {
+	mock := &mockProvider{
+		id: "mock",
+		chatResponse: &core.ChatResponse{
+			Model: "mock-model",
+			ToolCalls: []core.ToolCall{
+				{ID: "1", Name: "f", Arguments: json.RawMessage("{not valid json")},
+			},
+		},
+	}
+	adapter := NewProviderAdapter(mock)
+
+	_, err := adapter.Complete(context.Background(), petalflow.LLMRequest{
+		Model:     "mock-model",
+		InputText: "hi",
+	})
+	if err == nil {
+		t.Fatal("expected an error for malformed tool-call arguments, got nil")
 	}
 }

--- a/irisadapter/streaming.go
+++ b/irisadapter/streaming.go
@@ -14,7 +14,10 @@ import (
 // has Done=true and includes Usage if available from the provider.
 func (a *ProviderAdapter) CompleteStream(ctx context.Context, req petalflow.LLMRequest) (<-chan petalflow.StreamChunk, error) {
 	// Convert LLMRequest to core.ChatRequest (reuse existing conversion)
-	chatReq := a.toCoreChatRequest(req)
+	chatReq, err := a.toCoreChatRequest(req)
+	if err != nil {
+		return nil, err
+	}
 
 	// Call the provider's StreamChat
 	stream, err := a.provider.StreamChat(ctx, chatReq)

--- a/nodes/tool.go
+++ b/nodes/tool.go
@@ -3,6 +3,8 @@ package nodes
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/petal-labs/petalflow/core"
@@ -17,6 +19,11 @@ type ToolNodeConfig struct {
 	// ArgsTemplate maps argument names to envelope variable paths.
 	// Example: {"location": "user_location", "units": "preferences.units"}
 	ArgsTemplate map[string]string
+
+	// RequiredArgs lists argument names that must resolve to a value. If any is
+	// missing after building args, the node returns an error instead of invoking
+	// the tool with incomplete arguments.
+	RequiredArgs []string
 
 	// StaticArgs are arguments that don't come from the envelope.
 	StaticArgs map[string]any
@@ -193,6 +200,18 @@ func (n *ToolNode) buildArgs(env *core.Envelope) (map[string]any, error) {
 		if ok {
 			args[argName] = val
 		}
+	}
+
+	// Fail rather than invoke the tool with missing required arguments.
+	var missing []string
+	for _, name := range n.config.RequiredArgs {
+		if _, ok := args[name]; !ok {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		return nil, fmt.Errorf("missing required tool args: %s", strings.Join(missing, ", "))
 	}
 
 	return args, nil

--- a/nodes/tool_test.go
+++ b/nodes/tool_test.go
@@ -3,6 +3,7 @@ package nodes
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -161,6 +162,48 @@ func TestToolNode_Run_WithStaticArgs(t *testing.T) {
 	}
 	if args["version"] != 2 {
 		t.Errorf("expected version 2, got %v", args["version"])
+	}
+}
+
+func TestToolNode_Run_MissingRequiredArgErrors(t *testing.T) {
+	tool := &mockPetalTool{name: "t", result: map[string]any{"ok": true}}
+	node := NewToolNode("test", tool, ToolNodeConfig{
+		ArgsTemplate: map[string]string{"location": "user_location"},
+		RequiredArgs: []string{"location"},
+	})
+
+	// user_location is not set on the envelope.
+	result, err := node.Run(context.Background(), core.NewEnvelope())
+	if err == nil {
+		t.Fatal("expected an error for a missing required arg, got nil")
+	}
+	if !strings.Contains(err.Error(), "location") {
+		t.Errorf("error = %v, want it to name the missing arg", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil envelope on failure, got %v", result)
+	}
+	if len(tool.calls) != 0 {
+		t.Error("tool should not be invoked when a required arg is missing")
+	}
+}
+
+func TestToolNode_Run_RequiredArgPresentSucceeds(t *testing.T) {
+	tool := &mockPetalTool{name: "t", result: map[string]any{"ok": true}}
+	node := NewToolNode("test", tool, ToolNodeConfig{
+		ArgsTemplate: map[string]string{"location": "user_location"},
+		RequiredArgs: []string{"location"},
+		OutputKey:    "out",
+	})
+
+	env := core.NewEnvelope()
+	env.SetVar("user_location", "Tokyo")
+
+	if _, err := node.Run(context.Background(), env); err != nil {
+		t.Fatalf("unexpected error when required arg is present: %v", err)
+	}
+	if len(tool.calls) != 1 || tool.calls[0]["location"] != "Tokyo" {
+		t.Errorf("tool called with args %v, want location=Tokyo", tool.calls)
 	}
 }
 

--- a/registry/builtins.go
+++ b/registry/builtins.go
@@ -290,7 +290,7 @@ var builtinConfigKeys = map[string][]string{
 	"conditional":     {"default", "output_key", "evaluation_order", "pass_through", "conditions"},
 	"webhook_trigger": {"methods", "auth", "request_var", "body_var", "headers_var", "query_var", "metadata_var", "timeout"},
 	"webhook_call":    {"url", "method", "headers", "timeout", "max_response_bytes", "template", "result_var", "input_vars", "include_artifacts", "include_messages", "include_trace"},
-	"tool":            {"tool_name", "args_template", "static_args", "output_key", "timeout"},
+	"tool":            {"tool_name", "args_template", "static_args", "output_key", "timeout", "required_args"},
 }
 
 // applyBuiltinConfigKeys attaches the recognized config keys to each registered


### PR DESCRIPTION
Closes #148. Three silent-degradation points around tool calls now fail loudly.

## Change

1. **Malformed tool-call arguments (adapter).** `irisadapter/provider.go` did `_ = json.Unmarshal(tc.Arguments, &args) // best effort`, so a model returning invalid JSON tool-args ran the tool with an empty map. It now returns an error naming the tool call — consistent with #144's "surface, don't degrade".
2. **Unknown message role (adapter).** `toRole` coerced any unrecognized role to `user`. It now returns an error for unknown roles; `toCoreChatRequest`, `Complete`, and `CompleteStream` propagate it.
3. **Missing required tool args (node).** Added an opt-in `ToolNodeConfig.RequiredArgs` (graph config `required_args`). If a required arg doesn't resolve from the envelope, `buildArgs` returns an error and the tool is **not** invoked with incomplete arguments. Non-required args behave as before (optional omission), so this is non-breaking. Wired through the hydrate factory and added to the `tool` type's recognized config keys (so #147 doesn't warn on it).

The adapter changes touch only unexported functions; behavior becomes stricter (errors where previously silent), but no public API is removed.

## Testing

- TDD across both modules. Node: missing-required-arg errors and the tool isn't called; required-arg-present succeeds and passes the value through. Adapter: unknown role errors (naming the role); malformed tool-call arguments error; existing `toRole`/tool-result tests updated to the new signature.
- Main module `go build/vet/test ./...` green (23 packages, 0 failures); `irisadapter` module `go build/vet` + `go test -race ./...` clean; gofmt clean.