### PR TITLE
fix: bound tool-subsystem HTTP probes with timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `RequiredArgs` (config `required_args`): if a required argument does not
   resolve from the envelope, the node returns an error instead of invoking the
   tool with missing arguments.
+- **Tool-subsystem HTTP probes are now bounded by a timeout.** The MCP health
+  probe, the `http_fetch` builtin, the reachability checker (`CheckHTTP`), and
+  the MCP SSE transport used `http.DefaultClient`, which has no overall timeout,
+  so a stalled endpoint could hang a tool call or block the (sequential) health
+  loop indefinitely. They now use timeout-bounded clients (the health probe
+  honors the overlay's configured timeout).
 
 ### Added
 

--- a/tool/builtins.go
+++ b/tool/builtins.go
@@ -193,7 +193,7 @@ func (httpFetchTool) Invoke(ctx context.Context, action string, inputs map[strin
 		req.Header.Set("Authorization", auth)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := sharedHTTPClientPool.client(httpFetchTimeout).Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("http_fetch: request failed: %w", err)
 	}

--- a/tool/builtins_test.go
+++ b/tool/builtins_test.go
@@ -2,9 +2,8 @@ package tool
 
 import (
 	"context"
-	"io"
 	"net/http"
-	"strings"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -57,17 +56,10 @@ func TestTemplateRenderBuiltinInvoke(t *testing.T) {
 }
 
 func TestHTTPFetchBuiltinInvoke(t *testing.T) {
-	prevTransport := http.DefaultTransport
-	http.DefaultTransport = roundTripFunc(func(r *http.Request) (*http.Response, error) {
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(strings.NewReader("ok")),
-			Header:     make(http.Header),
-		}, nil
-	})
-	t.Cleanup(func() {
-		http.DefaultTransport = prevTransport
-	})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
 
 	native, ok := LookupBuiltinNativeTool("http_fetch")
 	if !ok {
@@ -78,7 +70,7 @@ func TestHTTPFetchBuiltinInvoke(t *testing.T) {
 	resp, err := adapter.Invoke(context.Background(), InvokeRequest{
 		Action: "fetch",
 		Inputs: map[string]any{
-			"url": "http://unit-test.local/ok",
+			"url": srv.URL + "/ok",
 		},
 	})
 	if err != nil {

--- a/tool/http_pool.go
+++ b/tool/http_pool.go
@@ -16,6 +16,15 @@ var sharedHTTPClientPool = &httpClientPool{
 	clients: map[time.Duration]*http.Client{},
 }
 
+// Timeouts bounding the tool subsystem's outbound HTTP probes, so a stalled
+// endpoint cannot hang a tool call or the (sequential) health-check loop. These
+// are vars rather than consts so tests can shorten them.
+var (
+	httpFetchTimeout        = 30 * time.Second
+	reachabilityHTTPTimeout = 10 * time.Second
+	defaultMCPHealthTimeout = 5 * time.Second
+)
+
 func (p *httpClientPool) client(timeout time.Duration) *http.Client {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/tool/http_timeout_test.go
+++ b/tool/http_timeout_test.go
@@ -1,0 +1,49 @@
+package tool
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHTTPFetch_TimesOut(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	old := httpFetchTimeout
+	httpFetchTimeout = 50 * time.Millisecond
+	defer func() { httpFetchTimeout = old }()
+
+	start := time.Now()
+	_, err := httpFetchTool{}.Invoke(context.Background(), "", map[string]any{"url": srv.URL}, nil)
+	if err == nil {
+		t.Fatal("expected http_fetch to time out against a stalled server, got nil error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("http_fetch took %v, expected it to be bounded by the client timeout", elapsed)
+	}
+}
+
+func TestCheckHTTP_TimesOut(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(300 * time.Millisecond)
+	}))
+	defer srv.Close()
+
+	old := reachabilityHTTPTimeout
+	reachabilityHTTPTimeout = 50 * time.Millisecond
+	defer func() { reachabilityHTTPTimeout = old }()
+
+	start := time.Now()
+	err := DefaultReachabilityChecker{}.CheckHTTP(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatal("expected CheckHTTP to time out against a stalled server, got nil error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("CheckHTTP took %v, expected it to be bounded by the client timeout", elapsed)
+	}
+}

--- a/tool/mcp/transport_sse.go
+++ b/tool/mcp/transport_sse.go
@@ -10,7 +10,13 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 )
+
+// sseDefaultTimeout bounds the JSON-RPC request/response calls made by the SSE
+// transport when the caller does not supply a client, so a stalled endpoint
+// cannot hang a health check or tool invocation indefinitely.
+var sseDefaultTimeout = 30 * time.Second
 
 // SSETransportConfig configures an MCP endpoint transport.
 // The current implementation uses request/response JSON-RPC over HTTP while
@@ -35,7 +41,7 @@ func NewSSETransport(cfg SSETransportConfig) (*SSETransport, error) {
 		return nil, errors.New("mcp: sse endpoint is required")
 	}
 	if cfg.Client == nil {
-		cfg.Client = http.DefaultClient
+		cfg.Client = &http.Client{Timeout: sseDefaultTimeout}
 	}
 	return &SSETransport{
 		cfg:    cfg,

--- a/tool/mcp/transport_sse_timeout_test.go
+++ b/tool/mcp/transport_sse_timeout_test.go
@@ -1,0 +1,16 @@
+package mcp
+
+import "testing"
+
+func TestNewSSETransport_DefaultClientHasTimeout(t *testing.T) {
+	tr, err := NewSSETransport(SSETransportConfig{Endpoint: "http://example.com"})
+	if err != nil {
+		t.Fatalf("NewSSETransport() error = %v", err)
+	}
+	if tr.cfg.Client == nil {
+		t.Fatal("expected a default HTTP client")
+	}
+	if tr.cfg.Client.Timeout <= 0 {
+		t.Errorf("default SSE transport client has no timeout (Timeout=%v)", tr.cfg.Client.Timeout)
+	}
+}

--- a/tool/mcp_health.go
+++ b/tool/mcp_health.go
@@ -9,6 +9,15 @@ import (
 )
 
 // EvaluateMCPHealth checks MCP availability using overlay strategy hints.
+// mcpHealthTimeout returns the per-probe HTTP timeout, honoring the overlay's
+// configured health timeout and falling back to a default.
+func mcpHealthTimeout(overlay *MCPOverlay) time.Duration {
+	if overlay != nil && overlay.Health.TimeoutMS > 0 {
+		return time.Duration(overlay.Health.TimeoutMS) * time.Millisecond
+	}
+	return defaultMCPHealthTimeout
+}
+
 func EvaluateMCPHealth(ctx context.Context, reg Registration) HealthReport {
 	report := HealthReport{
 		ToolName:  reg.Name,
@@ -46,7 +55,7 @@ func EvaluateMCPHealth(ctx context.Context, reg Registration) HealthReport {
 			report.ErrorMessage = err.Error()
 			return report
 		}
-		resp, err := http.DefaultClient.Do(req)
+		resp, err := sharedHTTPClientPool.client(mcpHealthTimeout(overlay)).Do(req)
 		if err != nil {
 			report.State = HealthUnhealthy
 			report.ErrorMessage = err.Error()

--- a/tool/registration_validation.go
+++ b/tool/registration_validation.go
@@ -47,7 +47,7 @@ func (DefaultReachabilityChecker) CheckHTTP(ctx context.Context, endpoint string
 		return fmt.Errorf("invalid endpoint: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := sharedHTTPClientPool.client(reachabilityHTTPTimeout).Do(req)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #150.

## Problem
Several tool-subsystem HTTP call sites used `http.DefaultClient` (no overall timeout), relying only on a caller context that may have no deadline:
- `tool/mcp_health.go` — MCP health probe
- `tool/builtins.go` — `http_fetch` builtin
- `tool/registration_validation.go` — `CheckHTTP` reachability probe
- `tool/mcp/transport_sse.go` — default client for the JSON-RPC-over-HTTP transport

A stalled endpoint could hang a tool call, and since the health scheduler probes **sequentially** with a deadline-less `context.Background()`, one stuck endpoint blocked the whole loop.

## Change
- The three `tool`-package sites now use the existing timeout-bounded client pool (`sharedHTTPClientPool.client(...)`). The MCP health probe honors the overlay's configured timeout (`Health.TimeoutMS`) with a default fallback; `http_fetch` and `CheckHTTP` use fixed default caps.
- `mcp/transport_sse.go` now defaults to a bounded client (its `Do` is a request/response JSON-RPC POST that reads the full body — not a long-lived stream — so an overall `Timeout` is safe).
- Timeout values are package vars so tests can shorten them.

## Testing
- TDD: `http_fetch` and `CheckHTTP` time out against a stalled `httptest` server (bounded well under 1s once the client timeout is shortened); the SSE transport's default client has a non-zero `Timeout`.
- Updated the existing `http_fetch` builtin test to use an `httptest` server, since it previously mocked via `http.DefaultTransport` (bypassed now that `http_fetch` uses its own bounded client's transport).
- `go build/vet/test ./...` green (23 packages, 0 failures); gofmt/vet clean.