### PR TITLE
fix: return a deterministic result envelope from parallel runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so a stalled endpoint could hang a tool call or block the (sequential) health
   loop indefinitely. They now use timeout-bounded clients (the health probe
   honors the overlay's configured timeout).
+- **Parallel runs now return a deterministic result envelope.** With
+  `Concurrency > 1`, the runtime returned whichever branch finished last, so a
+  graph with multiple non-merged leaf nodes produced a nondeterministic result.
+  The result is now the completed envelope of the last sink node in
+  node-insertion order, independent of scheduling.
 
 ### Added
 

--- a/runtime/parallel_result_test.go
+++ b/runtime/parallel_result_test.go
@@ -1,0 +1,50 @@
+package runtime_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/petal-labs/petalflow/core"
+	"github.com/petal-labs/petalflow/graph"
+	"github.com/petal-labs/petalflow/runtime"
+)
+
+// TestRuntime_Run_ParallelResultIsDeterministic fans out to two non-merged leaf
+// nodes. The result must be deterministic across runs regardless of which
+// branch finishes first. Leaf "a" sleeps so that, under the old "last result
+// wins" logic, it would arrive last and be returned; the runtime must instead
+// return the designated sink ("b", the last sink in node-insertion order).
+func TestRuntime_Run_ParallelResultIsDeterministic(t *testing.T) {
+	g := graph.NewGraph("fanout")
+	g.AddNode(core.NewFuncNode("start", func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		env.SetVar("started", true)
+		return env, nil
+	}))
+	g.AddNode(core.NewFuncNode("a", func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		time.Sleep(5 * time.Millisecond)
+		env.SetVar("leaf", "a")
+		return env, nil
+	}))
+	g.AddNode(core.NewFuncNode("b", func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		env.SetVar("leaf", "b")
+		return env, nil
+	}))
+	g.AddEdge("start", "a")
+	g.AddEdge("start", "b")
+	g.SetEntry("start")
+
+	rt := runtime.NewRuntime()
+	opts := runtime.DefaultRunOptions()
+	opts.Concurrency = 2
+
+	for i := 0; i < 10; i++ {
+		result, err := rt.Run(context.Background(), g, core.NewEnvelope(), opts)
+		if err != nil {
+			t.Fatalf("run %d: unexpected error: %v", i, err)
+		}
+		if v, _ := result.GetVar("leaf"); v != "b" {
+			t.Fatalf("run %d: result leaf = %v, want deterministic %q (last sink)", i, v, "b")
+		}
+	}
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -594,6 +594,19 @@ func (p *parallelState) incrementHop(nodeID string) (int, *core.Envelope) {
 	return state.hopCount, state.envelope
 }
 
+// completedEnvelope returns the stored envelope for a node that has completed,
+// or (nil, false) if the node has no state, has not completed, or has no envelope.
+func (p *parallelState) completedEnvelope(nodeID string) (*core.Envelope, bool) {
+	p.statesMu.Lock()
+	defer p.statesMu.Unlock()
+
+	s := p.states[nodeID]
+	if s == nil || !s.completed || s.envelope == nil {
+		return nil, false
+	}
+	return s.envelope, true
+}
+
 func (p *parallelState) markNodeCompleted(nodeID string, env *core.Envelope) {
 	p.statesMu.Lock()
 	defer p.statesMu.Unlock()
@@ -712,14 +725,39 @@ func (r *BasicRuntime) executeGraphParallel(
 	// Cleanup
 	stopWorkers()
 
-	if finalEnvelope == nil {
-		finalEnvelope = env
+	// Select the run result deterministically: the completed envelope of the
+	// last sink node (in node-insertion order). This avoids returning whichever
+	// branch happened to finish last, which is nondeterministic for graphs with
+	// multiple non-merged leaves. Fall back to the last observed envelope, then
+	// the input, if no sink completed.
+	result := selectParallelResult(g, state)
+	if result == nil {
+		result = finalEnvelope
+	}
+	if result == nil {
+		result = env
 	}
 
-	// Merge recorded errors into final envelope
-	state.appendRecordedErrors(finalEnvelope)
+	// Merge recorded errors into the result envelope.
+	state.appendRecordedErrors(result)
 
-	return finalEnvelope, nil
+	return result, nil
+}
+
+// selectParallelResult returns the completed envelope of the last sink node (a
+// node with no successors) in node-insertion order, or nil if no sink completed.
+func selectParallelResult(g graph.Graph, state *parallelState) *core.Envelope {
+	var result *core.Envelope
+	for _, node := range g.Nodes() {
+		id := node.ID()
+		if len(g.Successors(id)) != 0 {
+			continue // not a sink
+		}
+		if env, ok := state.completedEnvelope(id); ok {
+			result = env
+		}
+	}
+	return result
 }
 
 func (r *BasicRuntime) startParallelWorkers(


### PR DESCRIPTION
Closes #151.

## Problem
In `executeGraphParallel`, `finalEnvelope = resultEnvelope` was reassigned on every processed result while `pendingCount > 0`. Because branches complete in a nondeterministic order under `Concurrency > 1`, a graph with multiple non-merged leaf nodes returned an arbitrary branch's envelope — different run to run. Fine when the graph converges to a single sink; wrong otherwise.

## Change
After all work completes, select the result deterministically: the completed envelope of the **last sink node** (a node with no successors) in **node-insertion order**, independent of scheduling. Falls back to the last observed envelope, then the input, if no sink completed. Adds a `parallelState.completedEnvelope` accessor (lock-guarded).

Single-sink graphs are unaffected in intent (the sink is the result); the change removes the case where a late-finishing dangling branch could displace the sink's envelope.

## Testing
- TDD: a fan-out to two non-merged leaves where the non-sink leaf sleeps so the old "last result wins" logic reliably returned it; the runtime must instead return the designated sink, deterministically across 10 runs. (RED returned the sleeping leaf; GREEN returns the sink.)
- `go test -race ./runtime/` clean; full `go build/vet/test ./...` green (23 packages, 0 failures) — no existing test relied on the old behavior.