### PR TITLE
fix: normalize nil Vars and make TopologicalSort deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   graph with multiple non-merged leaf nodes produced a nondeterministic result.
   The result is now the completed envelope of the last sink node in
   node-insertion order, independent of scheduling.
+- **Hand-built envelopes with a nil `Vars` map are normalized before a run**, so
+  a node that writes directly to `env.Vars` no longer panics when a caller
+  passes `&Envelope{}` instead of using `NewEnvelope()`.
+- **`graph.TopologicalSort` is now deterministic.** It seeded its work queue
+  from map iteration order; it now seeds in node-insertion order.
 
 ### Added
 

--- a/graph/graph.go
+++ b/graph/graph.go
@@ -201,10 +201,11 @@ func (g *BasicGraph) TopologicalSort(allowCycles bool) ([]string, error) {
 		inDegree[id] = len(g.predecessors[id])
 	}
 
-	// Start with nodes that have no predecessors
+	// Start with nodes that have no predecessors, in insertion order so the
+	// result is deterministic (map iteration order is not).
 	queue := make([]string, 0)
-	for id, degree := range inDegree {
-		if degree == 0 {
+	for _, id := range g.nodeOrder {
+		if inDegree[id] == 0 {
 			queue = append(queue, id)
 		}
 	}

--- a/graph/toposort_test.go
+++ b/graph/toposort_test.go
@@ -1,0 +1,40 @@
+package graph
+
+import (
+	"testing"
+
+	"github.com/petal-labs/petalflow/core"
+)
+
+// TestBasicGraph_TopologicalSort_Deterministic verifies the sort produces the
+// same order every call. Nodes "a" and "b" both have in-degree 0, so a
+// map-seeded queue would order them nondeterministically across calls.
+func TestBasicGraph_TopologicalSort_Deterministic(t *testing.T) {
+	g := NewGraph("x")
+	for _, id := range []string{"a", "b", "c", "d"} {
+		g.AddNode(core.NewNoopNode(id))
+	}
+	g.AddEdge("a", "c")
+	g.AddEdge("b", "c")
+	g.AddEdge("c", "d")
+
+	first, err := g.TopologicalSort(false)
+	if err != nil {
+		t.Fatalf("TopologicalSort() error = %v", err)
+	}
+
+	for i := 0; i < 50; i++ {
+		got, err := g.TopologicalSort(false)
+		if err != nil {
+			t.Fatalf("TopologicalSort() error = %v", err)
+		}
+		if len(got) != len(first) {
+			t.Fatalf("length changed: %v vs %v", got, first)
+		}
+		for j := range got {
+			if got[j] != first[j] {
+				t.Fatalf("nondeterministic order: run %d = %v, first = %v", i, got, first)
+			}
+		}
+	}
+}

--- a/runtime/env_init_test.go
+++ b/runtime/env_init_test.go
@@ -1,0 +1,32 @@
+package runtime_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/petal-labs/petalflow/core"
+	"github.com/petal-labs/petalflow/graph"
+	"github.com/petal-labs/petalflow/runtime"
+)
+
+// TestRuntime_Run_InitializesNilVarsOnHandBuiltEnvelope ensures a caller passing
+// a hand-built &core.Envelope{} (non-nil but with a nil Vars map) is normalized,
+// so a node that writes directly to env.Vars does not hit an assignment-to-nil-map.
+func TestRuntime_Run_InitializesNilVarsOnHandBuiltEnvelope(t *testing.T) {
+	g := graph.NewGraph("x")
+	g.AddNode(core.NewFuncNode("a", func(ctx context.Context, env *core.Envelope) (*core.Envelope, error) {
+		env.Vars["direct"] = "written" // direct map write panics if Vars is nil
+		return env, nil
+	}))
+	g.SetEntry("a")
+
+	rt := runtime.NewRuntime()
+
+	result, err := rt.Run(context.Background(), g, &core.Envelope{}, runtime.DefaultRunOptions())
+	if err != nil {
+		t.Fatalf("unexpected error for a hand-built envelope with nil Vars: %v", err)
+	}
+	if v, _ := result.GetVar("direct"); v != "written" {
+		t.Errorf("direct var = %v, want %q", v, "written")
+	}
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -204,9 +204,13 @@ func (r *BasicRuntime) Run(ctx context.Context, g graph.Graph, env *core.Envelop
 		return nil, err
 	}
 
-	// Initialize envelope if nil
+	// Initialize envelope if nil, and normalize a hand-built envelope whose
+	// Vars map is nil so nodes that write directly to env.Vars do not panic.
 	if env == nil {
 		env = core.NewEnvelope()
+	}
+	if env.Vars == nil {
+		env.Vars = make(map[string]any)
 	}
 
 	// Generate run ID


### PR DESCRIPTION
Closes #153. Two minor robustness gaps from the hardening audit.

## 1. Hand-built envelope with nil `Vars`
The runtime re-initialized the envelope only when it was `nil`. A caller passing `&core.Envelope{}` (non-nil, nil `Vars`) was not normalized, so a node writing directly to `env.Vars` hit an assignment-to-nil-map panic (now caught by the node-panic recovery from #139, but surfacing as a run error). `Run` now initializes `Vars` when nil.

## 2. Nondeterministic `TopologicalSort`
`graph.TopologicalSort` seeded its Kahn's-algorithm queue with `for id := range inDegree` (map iteration order), so root nodes were ordered nondeterministically. It now seeds from `nodeOrder` (insertion order); successor iteration was already slice-ordered. (Currently unused in the production execution path, but no longer a latent trap.)

## Testing
- TDD: a hand-built `&Envelope{}` run where a node writes directly to `env.Vars` succeeds (RED panicked → node error; GREEN succeeds). `TopologicalSort` returns the same order across 50 calls for a graph with two in-degree-0 roots (RED flipped root order; GREEN stable).
- `go build/vet/test ./...` green (23 packages, 0 failures); gofmt/vet clean.