### PR TITLE
fix: deliver events in sequence order and count dropped events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   passes `&Envelope{}` instead of using `NewEnvelope()`.
 - **`graph.TopologicalSort` is now deterministic.** It seeded its work queue
   from map iteration order; it now seeds in node-insertion order.
+- **Events are delivered in monotonic sequence order under concurrency.** In
+  parallel mode, workers could assign sequence numbers and then deliver out of
+  order, which also caused the SSE stream to silently drop a later-arriving
+  lower-sequence event via its dedup high-water mark. Event emission is now
+  serialized, so subscribers and the `EventHandler` observe events in `Seq`
+  order and the `EventHandler` is never invoked concurrently (it should be fast
+  and non-blocking). Dropped events are now observable: `BasicRuntime.DroppedEvents()`
+  counts events discarded when the `Events()` channel is full, and
+  `Subscription.Dropped()` counts per-subscriber buffer overflows.
 
 ### Added
 

--- a/bus/bus.go
+++ b/bus/bus.go
@@ -30,4 +30,8 @@ type Subscription interface {
 
 	// Close unsubscribes and releases resources.
 	Close() error
+
+	// Dropped returns the cumulative number of events dropped for this
+	// subscription because its buffer was full (the consumer fell behind).
+	Dropped() uint64
 }

--- a/bus/membus.go
+++ b/bus/membus.go
@@ -2,6 +2,7 @@ package bus
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"github.com/petal-labs/petalflow/runtime"
 )
@@ -140,9 +141,10 @@ func removeSub(subs []*memSub, target *memSub) []*memSub {
 
 // memSub is an in-memory subscription.
 type memSub struct {
-	ch     chan runtime.Event
-	mu     sync.Mutex
-	closed bool
+	ch      chan runtime.Event
+	mu      sync.Mutex
+	closed  bool
+	dropped atomic.Uint64
 
 	// bus, runID, and global identify where this subscription is registered so
 	// it can deregister itself on Close. Set once at subscription time.
@@ -203,8 +205,15 @@ func (s *memSub) send(event runtime.Event) {
 	select {
 	case s.ch <- event:
 	default:
-		// Drop if channel full.
+		// Buffer full: drop the event and record it for observability.
+		s.dropped.Add(1)
 	}
+}
+
+// Dropped returns the cumulative number of events dropped for this subscription
+// because its buffer was full.
+func (s *memSub) Dropped() uint64 {
+	return s.dropped.Load()
 }
 
 // Compile-time interface checks.

--- a/bus/membus_dropped_test.go
+++ b/bus/membus_dropped_test.go
@@ -1,0 +1,21 @@
+package bus
+
+import (
+	"testing"
+
+	"github.com/petal-labs/petalflow/runtime"
+)
+
+func TestMemBus_Send_CountsDrops(t *testing.T) {
+	b := NewMemBus(MemBusConfig{SubscriberBufferSize: 2})
+	sub := b.Subscribe("r")
+
+	// Publish more than the buffer holds without draining; the excess is dropped.
+	for i := 0; i < 5; i++ {
+		b.Publish(runtime.Event{RunID: "r"})
+	}
+
+	if sub.Dropped() == 0 {
+		t.Error("expected Dropped > 0 on a full subscriber buffer")
+	}
+}

--- a/runtime/emit_order_test.go
+++ b/runtime/emit_order_test.go
@@ -1,0 +1,74 @@
+package runtime_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/petal-labs/petalflow/core"
+	"github.com/petal-labs/petalflow/graph"
+	"github.com/petal-labs/petalflow/runtime"
+)
+
+// TestRuntime_Run_ParallelEmitSerializedAndOrdered verifies that events are
+// delivered to the EventHandler serially and in monotonic Seq order even under
+// concurrent execution. The handler appends without a lock on purpose: that is
+// safe only if emit serializes handler invocation. Run under `go test -race`,
+// unserialized emit is a data race; and out-of-order delivery breaks the
+// strictly-increasing assertion.
+func TestRuntime_Run_ParallelEmitSerializedAndOrdered(t *testing.T) {
+	var seqs []uint64
+	handler := func(e runtime.Event) {
+		seqs = append(seqs, e.Seq)
+	}
+
+	g := graph.NewGraph("fanout")
+	g.AddNode(core.NewNoopNode("start"))
+	for _, id := range []string{"a", "b", "c", "d", "e", "f"} {
+		g.AddNode(core.NewNoopNode(id))
+		g.AddEdge("start", id)
+	}
+	g.SetEntry("start")
+
+	rt := runtime.NewRuntime()
+	opts := runtime.DefaultRunOptions()
+	opts.Concurrency = 6
+	opts.EventHandler = handler
+
+	if _, err := rt.Run(context.Background(), g, core.NewEnvelope(), opts); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(seqs) < 2 {
+		t.Fatalf("expected multiple events, got %d", len(seqs))
+	}
+	for i := 1; i < len(seqs); i++ {
+		if seqs[i] <= seqs[i-1] {
+			t.Fatalf("event seqs not strictly increasing at index %d: %v", i, seqs)
+		}
+	}
+}
+
+func TestRuntime_Run_CountsDroppedEvents(t *testing.T) {
+	// A long chain emits far more events than the (unread) event channel buffers.
+	g := graph.NewGraph("chain")
+	prev := ""
+	for i := 0; i < 150; i++ {
+		id := fmt.Sprintf("n%d", i)
+		g.AddNode(core.NewNoopNode(id))
+		if prev != "" {
+			g.AddEdge(prev, id)
+		}
+		prev = id
+	}
+	g.SetEntry("n0")
+
+	rt := runtime.NewRuntime()
+	if _, err := rt.Run(context.Background(), g, core.NewEnvelope(), runtime.DefaultRunOptions()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if rt.DroppedEvents() == 0 {
+		t.Error("expected DroppedEvents > 0 when the event channel is not drained")
+	}
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"runtime/debug"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/petal-labs/petalflow/core"
@@ -122,7 +123,10 @@ type RunOptions struct {
 	// Now provides the current time (for testing). If nil, uses time.Now.
 	Now func() time.Time
 
-	// EventHandler receives events during execution.
+	// EventHandler receives events during execution. It is invoked serially and
+	// in monotonic Seq order, even under parallel execution, so it need not be
+	// safe for concurrent use — but it should be fast and non-blocking, since it
+	// runs on the emit critical path.
 	EventHandler EventHandler
 
 	// EventEmitterDecorator wraps the internal event emitter.
@@ -175,6 +179,17 @@ func DefaultRunOptions() RunOptions {
 // BasicRuntime is a simple sequential runtime implementation.
 type BasicRuntime struct {
 	eventCh chan Event
+
+	// droppedEvents counts events discarded because the Events() channel was
+	// full (no reader keeping up). Observable via DroppedEvents().
+	droppedEvents atomic.Uint64
+}
+
+// DroppedEvents returns the cumulative number of events dropped because the
+// Events() channel buffer was full. A non-zero value means an event consumer is
+// not keeping up (or Events() is not being read).
+func (r *BasicRuntime) DroppedEvents() uint64 {
+	return r.droppedEvents.Load()
 }
 
 // NewRuntime creates a new runtime instance.
@@ -220,7 +235,15 @@ func (r *BasicRuntime) Run(ctx context.Context, g graph.Graph, env *core.Envelop
 
 	// Create event emitter
 	seq := newSeqGen()
+	// emit is serialized so that sequence assignment and delivery are atomic:
+	// subscribers and the EventHandler observe events in monotonic Seq order,
+	// and the EventHandler is never invoked concurrently (even under parallel
+	// execution). EventHandlers should therefore be fast and non-blocking.
+	var emitMu sync.Mutex
 	emit := func(e Event) {
+		emitMu.Lock()
+		defer emitMu.Unlock()
+
 		e.Seq = seq.Next()
 		if opts.EventBus != nil {
 			opts.EventBus.Publish(e)
@@ -231,7 +254,8 @@ func (r *BasicRuntime) Run(ctx context.Context, g graph.Graph, env *core.Envelop
 		select {
 		case r.eventCh <- e:
 		default:
-			// Drop if channel is full
+			// Channel full: drop the event and record it for observability.
+			r.droppedEvents.Add(1)
 		}
 	}
 	if opts.EventEmitterDecorator != nil {


### PR DESCRIPTION
Closes #149.

## Problem
Under `Concurrency > 1`, workers assigned monotonic `Seq` numbers atomically but then called `Publish`/`EventHandler` in whatever order they were scheduled, so:
- Subscribers and the `EventHandler` could observe events **out of Seq order**.
- The SSE stream's dedup high-water mark (`if evt.Seq <= *lastSeq { continue }`) would **silently and permanently drop** a later-arriving lower-Seq event.
- The `EventHandler` could be invoked **concurrently** with no documented thread-safety contract.
- Backpressure drops (event channel full, subscriber buffer full) were silent.

## Change
- **Serialize `emit`.** Sequence assignment and delivery (`Publish` → `EventHandler` → event channel) now happen under one mutex, so delivery order matches `Seq` order and the `EventHandler` is never called concurrently. This makes the "monotonic per-run sequence" claim true for *delivery*, and eliminates the SSE silent-drop (a lower-Seq event can no longer arrive after a higher one). Documented on the `EventHandler` field: invoked serially in Seq order; should be fast/non-blocking.
- **Drop metrics.** `BasicRuntime.DroppedEvents()` counts events discarded when the `Events()` channel is full; `Subscription.Dropped()` (added to the interface, implemented on `memSub`) counts per-subscriber buffer overflows.

Tradeoff: `emit` is a serialization point in parallel mode. Events are lightweight relative to node work, and handlers are expected to be fast; correctness of ordering is worth it.

## Testing
- TDD: events are delivered strictly increasing by `Seq` under `Concurrency=6` — the handler appends **without a lock**, which is a data race caught by `go test -race` unless emit serializes (validates both ordering and serialization). A long chain overflows the unread event channel and `DroppedEvents() > 0`. A small MemBus buffer overflows and `Dropped() > 0`.
- `go build/vet/test ./...` green (23 packages, 0 failures); `go test -race ./runtime/ ./bus/ ./sse/` clean; gofmt/vet clean.