### PR TITLE
feat: validate structured LLM output against its JSON Schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Completed the `EnvelopeJSON` wire contract.** Added `input`, per-message and
   per-artifact `meta`, and trace `parent_id`/`span_id`, which were previously
   discarded during serialization.
+- **Structured LLM output is now validated for full JSON Schema conformance.**
+  Previously a configured `JSONSchema` only required the output to be a JSON
+  object; it now validates the output against the schema (required fields,
+  types, enums, patterns, nested schemas, etc.) and returns an error on
+  non-conformance. Validation is on by default whenever a `JSONSchema` is set.
+  Adds a dependency on `github.com/santhosh-tekuri/jsonschema/v6`.
 - **BREAKING: unified error handling on the runtime.** Nodes now always return
   their error; the runtime alone decides whether to fail the run or record the
   error and continue, via `RunOptions.ContinueOnError`. Removed the per-node

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -8,7 +8,11 @@ require (
 	github.com/petal-labs/petalflow/irisadapter v0.0.0-00010101000000-000000000000
 )
 
-require github.com/google/uuid v1.6.0 // indirect
+require (
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	golang.org/x/text v0.34.0 // indirect
+)
 
 // Development replace directives - remove once packages are published
 replace github.com/petal-labs/petalflow => ../

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,3 +1,5 @@
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -18,6 +20,8 @@ github.com/petal-labs/iris v0.15.0 h1:jcHgEFjfgUbUqSWPpnbH71HtkDGZcLZ1O7b/PYjTb1
 github.com/petal-labs/iris v0.15.0/go.mod h1:IadY26OyFubV/DE/e9YQ0t06NzikLeLk9nafoJv7/dA=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 h1:mgKeJMpvi0yx/sU5GsxQ7p6s2wtOnGAHZWCHUM4KGzY=

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.6
 	github.com/petal-labs/iris v0.15.0
 	github.com/robfig/cron/v3 v3.0.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2
 	go.opentelemetry.io/otel v1.40.0
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.35.0

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6N
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
@@ -54,6 +56,8 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
 github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/irisadapter/go.mod
+++ b/irisadapter/go.mod
@@ -7,7 +7,11 @@ require (
 	github.com/petal-labs/petalflow v0.1.0
 )
 
-require github.com/google/uuid v1.6.0 // indirect
+require (
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	golang.org/x/text v0.34.0 // indirect
+)
 
 // Development replace directive - remove once petalflow is published
 replace github.com/petal-labs/petalflow => ../

--- a/irisadapter/go.sum
+++ b/irisadapter/go.sum
@@ -1,3 +1,5 @@
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -18,6 +20,8 @@ github.com/petal-labs/iris v0.15.0 h1:jcHgEFjfgUbUqSWPpnbH71HtkDGZcLZ1O7b/PYjTb1
 github.com/petal-labs/iris v0.15.0/go.mod h1:IadY26OyFubV/DE/e9YQ0t06NzikLeLk9nafoJv7/dA=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 golang.org/x/crypto v0.47.0 h1:V6e3FRj+n4dbpw86FJ8Fv7XVOql7TEwpHapKoMJ/GO8=
 golang.org/x/crypto v0.47.0/go.mod h1:ff3Y9VzzKbwSSEzWqJsJVBnWmRwRSHt/6Op5n9bQc4A=
 golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546 h1:mgKeJMpvi0yx/sU5GsxQ7p6s2wtOnGAHZWCHUM4KGzY=

--- a/nodes/llm.go
+++ b/nodes/llm.go
@@ -9,6 +9,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/santhosh-tekuri/jsonschema/v6"
+
 	"github.com/petal-labs/petalflow/core"
 	"github.com/petal-labs/petalflow/runtime"
 )
@@ -60,6 +62,12 @@ type LLMNode struct {
 	core.BaseNode
 	config LLMNodeConfig
 	client core.LLMClient
+
+	// schema is the compiled JSONSchema (nil if none configured). schemaErr
+	// holds a compile error to surface at run time, since NewLLMNode has no
+	// error return.
+	schema    *jsonschema.Schema
+	schemaErr error
 }
 
 // NewLLMNode creates a new LLM node with the given configuration.
@@ -75,11 +83,15 @@ func NewLLMNode(id string, client core.LLMClient, config LLMNodeConfig) *LLMNode
 		config.Timeout = 60 * time.Second
 	}
 
-	return &LLMNode{
+	node := &LLMNode{
 		BaseNode: core.NewBaseNode(id, core.NodeKindLLM),
 		config:   config,
 		client:   client,
 	}
+	if config.JSONSchema != nil {
+		node.schema, node.schemaErr = compileJSONSchema(config.JSONSchema)
+	}
+	return node
 }
 
 // Run executes the LLM call and stores the result in the envelope.
@@ -379,14 +391,30 @@ func (n *LLMNode) finalizeOutput(text string, preParsed map[string]any) (any, er
 	if n.config.JSONSchema == nil {
 		return text, nil
 	}
-	if preParsed != nil {
-		return preParsed, nil
+	if n.schemaErr != nil {
+		return nil, fmt.Errorf("structured output for node %q: invalid JSONSchema: %w", n.ID(), n.schemaErr)
 	}
-	parsed, err := parseJSONObject(text)
-	if err != nil {
-		return nil, fmt.Errorf("structured output for node %q: model did not return a valid JSON object: %w", n.ID(), err)
+
+	obj := preParsed
+	if obj == nil {
+		parsed, err := parseJSONObject(text)
+		if err != nil {
+			return nil, fmt.Errorf("structured output for node %q: model did not return a valid JSON object: %w", n.ID(), err)
+		}
+		obj = parsed
 	}
-	return parsed, nil
+
+	if n.schema != nil {
+		instance, err := schemaInstance(text, obj)
+		if err != nil {
+			return nil, fmt.Errorf("structured output for node %q: %w", n.ID(), err)
+		}
+		if err := n.schema.Validate(instance); err != nil {
+			return nil, fmt.Errorf("structured output for node %q: output does not conform to schema: %w", n.ID(), err)
+		}
+	}
+
+	return obj, nil
 }
 
 // parseJSONObject parses s into a JSON object, rejecting empty or non-object output.
@@ -400,6 +428,39 @@ func parseJSONObject(s string) (map[string]any, error) {
 		return nil, err
 	}
 	return out, nil
+}
+
+// compileJSONSchema compiles a JSON Schema (as a decoded map) for validation.
+func compileJSONSchema(schema map[string]any) (*jsonschema.Schema, error) {
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return nil, err
+	}
+	doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	c := jsonschema.NewCompiler()
+	const loc = "petalflow://llm-node/schema"
+	if err := c.AddResource(loc, doc); err != nil {
+		return nil, err
+	}
+	return c.Compile(loc)
+}
+
+// schemaInstance decodes the model output into the value form the validator
+// expects (json.Number for numbers), preferring the raw text and falling back
+// to re-marshaling the parsed object.
+func schemaInstance(text string, obj map[string]any) (any, error) {
+	src := strings.TrimSpace(text)
+	if src == "" {
+		b, err := json.Marshal(obj)
+		if err != nil {
+			return nil, err
+		}
+		src = string(b)
+	}
+	return jsonschema.UnmarshalJSON(strings.NewReader(src))
 }
 
 // Config returns the node's configuration.

--- a/nodes/llm_test.go
+++ b/nodes/llm_test.go
@@ -295,6 +295,74 @@ func TestLLMNode_Run_Streaming_WithJSONSchema_InvalidJSONErrors(t *testing.T) {
 	}
 }
 
+func TestLLMNode_Run_StructuredOutput_NonConformingErrors(t *testing.T) {
+	// Valid JSON object, but missing the required "name" field.
+	client := &mockLLMClient{
+		response: core.LLMResponse{Text: `{"other": 1}`},
+	}
+	node := NewLLMNode("t", client, LLMNodeConfig{
+		Model: "gpt-4",
+		JSONSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"name": map[string]any{"type": "string"}},
+			"required":   []any{"name"},
+		},
+		OutputKey: "out",
+	})
+
+	_, err := node.Run(context.Background(), core.NewEnvelope())
+	if err == nil {
+		t.Fatal("expected a schema-conformance error for output missing a required field, got nil")
+	}
+	if !strings.Contains(err.Error(), "schema") && !strings.Contains(err.Error(), "conform") {
+		t.Errorf("error = %v, want it to mention schema conformance", err)
+	}
+}
+
+func TestLLMNode_Run_StructuredOutput_TypeMismatchErrors(t *testing.T) {
+	client := &mockLLMClient{
+		response: core.LLMResponse{Text: `{"age": "not a number"}`},
+	}
+	node := NewLLMNode("t", client, LLMNodeConfig{
+		Model: "gpt-4",
+		JSONSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"age": map[string]any{"type": "integer"}},
+			"required":   []any{"age"},
+		},
+		OutputKey: "out",
+	})
+
+	if _, err := node.Run(context.Background(), core.NewEnvelope()); err == nil {
+		t.Fatal("expected a schema-conformance error for a wrong-typed field, got nil")
+	}
+}
+
+func TestLLMNode_Run_StructuredOutput_ConformingPasses(t *testing.T) {
+	client := &mockLLMClient{
+		response: core.LLMResponse{Text: `{"name": "x"}`},
+	}
+	node := NewLLMNode("t", client, LLMNodeConfig{
+		Model: "gpt-4",
+		JSONSchema: map[string]any{
+			"type":       "object",
+			"properties": map[string]any{"name": map[string]any{"type": "string"}},
+			"required":   []any{"name"},
+		},
+		OutputKey: "out",
+	})
+
+	result, err := node.Run(context.Background(), core.NewEnvelope())
+	if err != nil {
+		t.Fatalf("unexpected error for conforming output: %v", err)
+	}
+	out, _ := result.GetVar("out")
+	m, ok := out.(map[string]any)
+	if !ok || m["name"] != "x" {
+		t.Errorf("output = %v, want a JSON object with name=x", out)
+	}
+}
+
 func TestLLMNode_Run_Error(t *testing.T) {
 	client := &mockLLMClient{
 		err: errors.New("API error"),


### PR DESCRIPTION
Closes #152. Follow-up to #144 (structured-output honesty).

## Problem
After #144, a configured `LLMNodeConfig.JSONSchema` only required the output to be a **JSON object** — schema constraints (required fields, types, enums, patterns, nested schemas) were not enforced, despite a schema implying them. Users could reasonably assume "conforms to this schema".

## Change
- Compile the node's `JSONSchema` once in `NewLLMNode` (storing the compiled schema; any compile error surfaces at run time since the constructor has no error return).
- In `finalizeOutput`, validate the model output against the compiled schema; non-conforming output returns an error. **On by default** whenever `JSONSchema` is set (per the agreed decision).
- Both the schema and the instance are decoded via `jsonschema.UnmarshalJSON` (which uses `json.Number`) so numeric constraints validate correctly. The value stored downstream remains the plain parsed map.

**Dependency:** adds `github.com/santhosh-tekuri/jsonschema/v6` (v6.0.2, the de-facto standard pure-Go validator, Apache-2.0), with `github.com/dlclark/regexp2` pulled in transitively (MIT, its pattern engine).

## Note for maintainer
The `NOTICE` file is a manually-maintained, selective list of third-party components. I did **not** modify it, since its inclusion policy isn't obvious (it lists 5 of the ~13 direct deps). Please add `santhosh-tekuri/jsonschema/v6` (and `dlclark/regexp2`) there if your attribution policy requires it.

## Scope note
This validates the library-level `JSONSchema` (set in Go). Graph-JSON LLM nodes don't currently expose a `json_schema` config key via the hydrate factory, so no example/graph workflows are affected; wiring it into graph config would be a separate enhancement.

## Testing
- TDD: non-conforming output (missing required field) errors; a wrong-typed field (`integer` vs string) errors; conforming output passes and is stored as a map. Existing object-only and streaming `JSONSchema` tests remain green (they use schemas the outputs satisfy).
- `go build/vet/test ./...` green (23 packages, 0 failures); `irisadapter` module builds; gofmt/vet clean.