### PR TITLE
chore: upgrade Iris to v0.17.0 and cut 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-08-03
 
 ### Fixed
 
@@ -127,6 +127,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Upgraded Iris dependency from v0.15.0 to v0.17.0.
 - **Completed the `EnvelopeJSON` wire contract.** Added `input`, per-message and
   per-artifact `meta`, and trace `parent_id`/`span_id`, which were previously
   discarded during serialization.

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,7 +3,7 @@ module github.com/petal-labs/petalflow/examples
 go 1.24.0
 
 require (
-	github.com/petal-labs/iris v0.15.0
+	github.com/petal-labs/iris v0.17.0
 	github.com/petal-labs/petalflow v0.1.0
 	github.com/petal-labs/petalflow/irisadapter v0.0.0-00010101000000-000000000000
 )

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -16,8 +16,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/petal-labs/iris v0.15.0 h1:jcHgEFjfgUbUqSWPpnbH71HtkDGZcLZ1O7b/PYjTb1U=
-github.com/petal-labs/iris v0.15.0/go.mod h1:IadY26OyFubV/DE/e9YQ0t06NzikLeLk9nafoJv7/dA=
+github.com/petal-labs/iris v0.17.0 h1:JsGdpX5K8OPQubI8i3NehQVxivsmwQ+nT6kcfjWiYGA=
+github.com/petal-labs/iris v0.17.0/go.mod h1:IadY26OyFubV/DE/e9YQ0t06NzikLeLk9nafoJv7/dA=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.7.6
-	github.com/petal-labs/iris v0.15.0
+	github.com/petal-labs/iris v0.17.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -45,8 +45,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/petal-labs/iris v0.15.0 h1:jcHgEFjfgUbUqSWPpnbH71HtkDGZcLZ1O7b/PYjTb1U=
-github.com/petal-labs/iris v0.15.0/go.mod h1:IadY26OyFubV/DE/e9YQ0t06NzikLeLk9nafoJv7/dA=
+github.com/petal-labs/iris v0.17.0 h1:JsGdpX5K8OPQubI8i3NehQVxivsmwQ+nT6kcfjWiYGA=
+github.com/petal-labs/iris v0.17.0/go.mod h1:IadY26OyFubV/DE/e9YQ0t06NzikLeLk9nafoJv7/dA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=

--- a/irisadapter/go.mod
+++ b/irisadapter/go.mod
@@ -3,7 +3,7 @@ module github.com/petal-labs/petalflow/irisadapter
 go 1.24.0
 
 require (
-	github.com/petal-labs/iris v0.15.0
+	github.com/petal-labs/iris v0.17.0
 	github.com/petal-labs/petalflow v0.1.0
 )
 

--- a/irisadapter/go.sum
+++ b/irisadapter/go.sum
@@ -16,8 +16,8 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
-github.com/petal-labs/iris v0.15.0 h1:jcHgEFjfgUbUqSWPpnbH71HtkDGZcLZ1O7b/PYjTb1U=
-github.com/petal-labs/iris v0.15.0/go.mod h1:IadY26OyFubV/DE/e9YQ0t06NzikLeLk9nafoJv7/dA=
+github.com/petal-labs/iris v0.17.0 h1:JsGdpX5K8OPQubI8i3NehQVxivsmwQ+nT6kcfjWiYGA=
+github.com/petal-labs/iris v0.17.0/go.mod h1:IadY26OyFubV/DE/e9YQ0t06NzikLeLk9nafoJv7/dA=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=


### PR DESCRIPTION
Closes #154, and upgrades to the latest Iris release.

## Iris upgrade
Upgraded `github.com/petal-labs/iris` from **v0.15.0 to v0.17.0** across all three modules (root, `irisadapter`, `examples`). No source changes were required — build, vet, and the full test suite pass on every module.

## 0.4.0 release
Retitled the CHANGELOG `[Unreleased]` section to `[0.4.0] - 2026-08-03`.

**This is a minor bump (0.3.0 → 0.4.0), not a patch,** because the release contains a breaking change: the unified error-handling refactor (#146) removed the per-node error policies (`ToolNodeConfig.OnError`, `WebhookCallErrorPolicy`, `core.ErrorPolicy`). Migration is documented in the CHANGELOG (use `RunOptions.ContinueOnError`).

### 0.4.0 highlights (the hardening sweep)
- **Reliability:** node panic recovery, per-node timeout, deep-clone envelope isolation, MemBus subscriber deregistration, deterministic parallel results, in-order event delivery.
- **Timeouts:** webhook/streaming/server/SSE/tool-subsystem HTTP all bounded.
- **Contracts:** node errors surfaced in the wire DTO, structured output validated for full JSON Schema conformance, unknown workflow fields rejected, tool-argument errors surfaced.

## After merge
Tag `v0.4.0` on the merge commit and publish release notes.

## Verification
Build/vet/test green on the root module (23 packages, 0 failures); `irisadapter` and `examples` modules build and test clean on Iris v0.17.0.